### PR TITLE
Allow overriding separator string between key/val pairs

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -14,6 +14,7 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
 
   private
   def ini_file
-    @ini_file ||= Puppet::Util::IniFile.new(resource[:path])
+    @ini_file ||= Puppet::Util::IniFile.new(resource[:path],
+                                            resource[:key_val_separator])
   end
 end

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -30,4 +30,11 @@ Puppet::Type.newtype(:ini_setting) do
     end
   end
 
+  newparam(:key_val_separator) do
+    desc 'The separator string to use between each setting name and value. ' +
+        'Defaults to " = ", but you could use this to override e.g. whether ' +
+        'or not the separator should include whitespace.'
+    defaultto(" = ")
+  end
+
 end

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -8,8 +8,9 @@ module Util
     SECTION_REGEX = /^\s*\[([\w\d\.\\\/\-\:]+)\]\s*$/
     SETTING_REGEX = /^\s*([\w\d\.\\\/\-]+)\s*=\s*([\S]+)\s*$/
 
-    def initialize(path)
+    def initialize(path, key_val_separator = ' = ')
       @path = path
+      @key_val_separator = key_val_separator
       @section_names = []
       @sections_hash = {}
       if File.file?(@path)
@@ -56,7 +57,7 @@ module Util
           end
 
           section.additional_settings.each_pair do |key, value|
-            fh.puts("#{key} = #{value}")
+            fh.puts("#{key}#{@key_val_separator}#{value}")
           end
         end
       end
@@ -106,7 +107,7 @@ module Util
       (section.start_line..section.end_line).each do |line_num|
         if (match = SETTING_REGEX.match(lines[line_num]))
           if (match[1] == setting)
-            lines[line_num] = "#{setting} = #{value}"
+            lines[line_num] = "#{setting}#{@key_val_separator}#{value}"
           end
         end
       end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -392,4 +392,48 @@ bar = baz
     end
   end
 
+  context "when overriding the separator" do
+    let(:orig_content) {
+      <<-EOS
+[section2]
+foo=bar
+      EOS
+    }
+
+    it "should modify an existing setting" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+                                                   :section           => 'section2',
+                                                   :setting           => 'foo',
+                                                   :value             => 'yippee',
+                                                   :key_val_separator => '='))
+      provider = described_class.new(resource)
+      provider.exists?.should == false
+      provider.create
+      validate_file(<<-EOS
+[section2]
+foo=yippee
+      EOS
+      )
+    end
+
+    it "should add a new setting" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+                                                   :section           => 'section2',
+                                                   :setting           => 'bar',
+                                                   :value             => 'baz',
+                                                   :key_val_separator => '='))
+      provider = described_class.new(resource)
+      provider.exists?.should == false
+      provider.create
+      validate_file(<<-EOS
+[section2]
+foo=bar
+bar=baz
+      EOS
+      )
+    end
+
+
+  end
+
 end

--- a/tests/ini_setting.pp
+++ b/tests/ini_setting.pp
@@ -7,10 +7,11 @@ ini_setting { "sample setting":
 }
 
 ini_setting { "sample setting2":
-  path    => '/tmp/foo.ini',
-  section => 'bar',
-  setting => 'barsetting',
-  value   => 'BAR!',
-  ensure  => present,
-  require => Ini_setting["sample setting"],
+  path                => '/tmp/foo.ini',
+  section             => 'bar',
+  setting             => 'barsetting',
+  value               => 'BAR!',
+  key_value_separator => '=',
+  ensure              => present,
+  require             => Ini_setting["sample setting"],
 }


### PR DESCRIPTION
This introduces a new parameter, 'key_val_separator', which
can be set in order to override the string that is used
as a separator between the key/value pair of a setting line.
The default is ' = ', but you could set the param to '=' if
you don't want to include whitespace in your settings file.
