### PR TITLE
Allow values with spaces to be parsed and set

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -6,7 +6,7 @@ module Util
   class IniFile
 
     SECTION_REGEX = /^\s*\[([\w\d\.\\\/\-\:]+)\]\s*$/
-    SETTING_REGEX = /^\s*([\w\d\.\\\/\-]+)\s*=\s*([\S]+)\s*$/
+    SETTING_REGEX = /^\s*([\w\d\.\\\/\-]+)\s*=\s*([\S\s]*\S)\s*$/
 
     def initialize(path, key_val_separator = ' = ')
       @path = path

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -26,6 +26,7 @@ foo= foovalue2
 baz=bazvalue
     #another comment
  ; yet another comment
+ zot = multi word value
       EOS
       template.split("\n")
     }
@@ -45,6 +46,7 @@ baz=bazvalue
       subject.get_value("section1", "bar").should == "barvalue"
       subject.get_value("section2", "foo").should == "foovalue2"
       subject.get_value("section2", "baz").should == "bazvalue"
+      subject.get_value("section2", "zot").should == "multi word value"
     end
 
   end


### PR DESCRIPTION
Previously, the following stanza would fail as a result of the ini_setting type not being able to parse spaces in setting values. Puppet would add a new line, `config_version = /etc/puppetlabs/puppet/config_version.sh`, on every run.

```
ini_setting { 'main_config_version':
  ensure  => present,
  path    => '/etc/puppetlabs/puppet/puppet.conf',
  section => 'main',
  setting => 'config_version',
  value   => '/etc/puppetlabs/puppet/config_version.sh $environment',
}
```

This commit modifes the SETTING_REGEX to account for spaces in setting values.
