### PR TITLE
changes for child provider usage

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -1,14 +1,24 @@
 require File.expand_path('../../../util/ini_file', __FILE__)
 
 Puppet::Type.type(:ini_setting).provide(:ruby) do
+
   def exists?
-    ini_file.get_value(resource[:section], resource[:setting]) == resource[:value].to_s
+    ini_file.get_value(section, setting)
   end
 
   def create
     ini_file.set_value(section, setting, resource[:value])
     ini_file.save
     @ini_file = nil
+  end
+
+  def value
+    ini_file.get_value(section, setting)
+  end
+
+  def value=(value)
+    ini_file.set_value(section, setting, resource[:value])
+    ini_file.save
   end
 
   def section

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -17,10 +17,6 @@ Puppet::Type.newtype(:ini_setting) do
     desc 'The name of the setting to be defined.'
   end
 
-  newparam(:value) do
-    desc 'The value of the setting to be defined.'
-  end
-
   newparam(:path) do
     desc 'The ini file Puppet will ensure contains the specified setting.'
     validate do |value|
@@ -42,5 +38,10 @@ Puppet::Type.newtype(:ini_setting) do
       end
     end
   end
+
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+  end
+
 
 end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -54,7 +54,7 @@ subby=bar
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :setting => 'yahoo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 # This is a comment
@@ -82,7 +82,7 @@ subby=bar
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => 'section:sub', :setting => 'yahoo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 # This is a comment
@@ -110,8 +110,8 @@ yahoo = yippee
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :setting => 'baz', :value => 'bazvalue2'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
-      provider.create
+      provider.exists?.should == 'bazvalue'
+      provider.value=('bazvalue2')
       validate_file(<<-EOS
 # This is a comment
 [section1]
@@ -137,8 +137,9 @@ subby=bar
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :section => 'section:sub', :setting => 'subby', :value => 'foo'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
-      provider.create
+      provider.exists?.should == 'bar'
+      provider.value.should == 'bar'
+      provider.value=('foo')
       validate_file(<<-EOS
 # This is a comment
 [section1]
@@ -164,8 +165,9 @@ subby = foo
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :setting => 'url', :value => 'http://192.168.0.1:8080'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
-      provider.create
+      provider.exists?.should == 'http://192.168.1.1:8080'
+      provider.value.should == 'http://192.168.1.1:8080'
+      provider.value=('http://192.168.0.1:8080')
 
       validate_file( <<-EOS
 # This is a comment
@@ -192,14 +194,14 @@ subby=bar
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :setting => 'baz', :value => 'bazvalue'))
       provider = described_class.new(resource)
-      provider.exists?.should == true
+      provider.exists?.should == 'bazvalue'
     end
 
     it "should add a new section if the section does not exist" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section3", :setting => 'huzzah', :value => 'shazaam'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 # This is a comment
@@ -229,7 +231,7 @@ huzzah = shazaam
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section:subsection", :setting => 'huzzah', :value => 'shazaam'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 # This is a comment
@@ -259,7 +261,7 @@ huzzah = shazaam
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section1", :setting => 'setting1', :value => 'hellowworld', :path => emptyfile))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file("
 [section1]
@@ -271,7 +273,7 @@ setting1 = hellowworld
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section:subsection", :setting => 'setting1', :value => 'hellowworld', :path => emptyfile))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file("
 [section:subsection]
@@ -283,8 +285,8 @@ setting1 = hellowworld
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section1", :setting => 'master', :value => true))
       provider = described_class.new(resource)
-      provider.exists?.should == true
-      provider.create
+      provider.exists?.should == 'true'
+      provider.value.should == 'true'
     end
 
   end
@@ -305,7 +307,7 @@ foo = http://192.168.1.1:8080
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => '', :setting => 'bar', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 # This is a comment
@@ -322,8 +324,9 @@ foo = http://192.168.1.1:8080
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :section => '', :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
-      provider.create
+      provider.exists?.should == 'blah'
+      provider.value.should == 'blah'
+      provider.value=('yippee')
       validate_file(<<-EOS
 # This is a comment
 foo = yippee
@@ -338,7 +341,7 @@ foo = http://192.168.1.1:8080
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :section => '', :setting => 'foo', :value => 'blah'))
       provider = described_class.new(resource)
-      provider.exists?.should == true
+      provider.exists?.should == 'blah'
     end
   end
 
@@ -354,7 +357,7 @@ foo = http://192.168.1.1:8080
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :section => '', :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 foo = yippee
@@ -368,8 +371,9 @@ foo = http://192.168.1.1:8080
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => 'section2', :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
-      provider.create
+      provider.exists?.should == 'http://192.168.1.1:8080'
+      provider.value.should == 'http://192.168.1.1:8080'
+      provider.value=('yippee')
       validate_file(<<-EOS
 [section2]
 foo = yippee
@@ -381,7 +385,7 @@ foo = yippee
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => 'section2', :setting => 'bar', :value => 'baz'))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 [section2]
@@ -427,8 +431,9 @@ foo=bar
                                                    :value             => 'yippee',
                                                    :key_val_separator => '='))
       provider = described_class.new(resource)
-      provider.exists?.should == false
-      provider.create
+      provider.exists?.should == 'bar'
+      provider.value.should == 'bar'
+      provider.value=('yippee')
       validate_file(<<-EOS
 [section2]
 foo=yippee
@@ -443,7 +448,7 @@ foo=yippee
                                                    :value             => 'baz',
                                                    :key_val_separator => '='))
       provider = described_class.new(resource)
-      provider.exists?.should == false
+      provider.exists?.should be_nil
       provider.create
       validate_file(<<-EOS
 [section2]


### PR DESCRIPTION
This commit series changed value from a parameter to a property and creates methods that can be used to
decouple this provider from its type so that it can be the parent class for other providers which manage a 
specific ini file. 
