### PR TITLE
add ensure=absent support

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -12,6 +12,12 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
     @ini_file = nil
   end
 
+  def destroy
+    ini_file.remove_setting(section, setting)
+    ini_file.save
+    @ini_file = nil
+  end
+
   def value
     ini_file.get_value(section, setting)
   end

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -42,17 +42,28 @@ module Util
       end
     end
 
+    def remove_setting(section_name, setting)
+      section = @sections_hash[section_name]
+      if (section.has_existing_setting?(setting))
+        remove_line(section, setting)
+        section.remove_existing_setting(setting)
+      end
+    end
+
     def save
       File.open(@path, 'w') do |fh|
 
         @section_names.each do |name|
+
           section = @sections_hash[name]
 
           if section.start_line.nil?
             fh.puts("\n[#{section.name}]")
           elsif ! section.end_line.nil?
             (section.start_line..section.end_line).each do |line_num|
-              fh.puts(lines[line_num])
+              if lines[line_num]
+                fh.puts(lines[line_num])
+              end
             end
           end
 
@@ -108,6 +119,16 @@ module Util
         if (match = SETTING_REGEX.match(lines[line_num]))
           if (match[1] == setting)
             lines[line_num] = "#{setting}#{@key_val_separator}#{value}"
+          end
+        end
+      end
+    end
+
+    def remove_line(section, setting)
+      (section.start_line..section.end_line).each do |line_num|
+        if (match = SETTING_REGEX.match(lines[line_num]))
+          if (match[1] == setting)
+            lines.delete_at(line_num)
           end
         end
       end

--- a/lib/puppet/util/ini_file/section.rb
+++ b/lib/puppet/util/ini_file/section.rb
@@ -24,6 +24,10 @@ class IniFile
       @existing_settings[setting_name] = value
     end
 
+    def remove_existing_setting(setting_name)
+      @existing_settings.delete(setting_name)
+    end
+
     def set_additional_setting(setting_name, value)
       @additional_settings[setting_name] = value
     end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -458,7 +458,53 @@ bar=baz
       )
     end
 
+  end
 
+  context "when ensuring that a setting is absent" do
+    let(:orig_content) {
+      <<-EOS
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+EOS
+    }
+
+    it "should remove a setting that exists" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+      :section => 'section1', :setting => 'foo', :ensure => 'absent'))
+      provider = described_class.new(resource)
+      provider.exists?.should be_true
+      provider.destroy
+      validate_file(<<-EOS
+[section1]
+; This is also a comment
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+EOS
+    )
+    end
   end
 
 end


### PR DESCRIPTION
This commit adds the ability to ensure that lines are absent.

Chris, please double check this. I was a little confused by the fact that the file lines indices need to be updated and at first was seeing nils printed to the resulting file.
