### PR TITLE
Make section/setting regexes more permissive

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -5,8 +5,8 @@ module Puppet
 module Util
   class IniFile
 
-    SECTION_REGEX = /^\s*\[([\w\d\.\\\/\-\:]+)\]\s*$/
-    SETTING_REGEX = /^(\s*)([\w\d\.\\\/\-]+)(\s*=\s*)([\S\s]*\S)\s*$/
+    SECTION_REGEX = /^\s*\[([ \w\d\.,\\\/\-_:;'"!?@#\$%^&*()\|]+?)\]\s*$/
+    SETTING_REGEX = /^(\s*)([ \w\d\.,\\\/\-_:;'"!?@#\$%^&*()\|]+?)(\s*=\s*)([\S\s]*?\S|)\s*$/
     COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([\w\d\.\\\/\-]+)(\s*=\s*)([\S\s]*\S)\s*$/
 
     def initialize(path, key_val_separator = ' = ')


### PR DESCRIPTION
This makes the section/setting regexes more permissive. Needed most of those characters to be allowed in order to properly parse KDE applications' rc files.
