### PR TITLE
Add purging support to ini file

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -2,6 +2,28 @@ require File.expand_path('../../../util/ini_file', __FILE__)
 
 Puppet::Type.type(:ini_setting).provide(:ruby) do
 
+  def self.instances
+    if self.respond_to?(:file_path)
+      # figure out what to do about the seperator
+      ini_file  = Puppet::Util::IniFile.new(file_path, '=')
+      resources = []
+      ini_file.section_names.each do |section_name|
+        ini_file.get_settings(section_name).each do |setting, value|
+          resources.push(
+            new(
+              :name   => "#{section_name}/#{setting}",
+              :value  => value,
+              :ensure => :present
+            )
+          )
+        end
+      end
+      resources
+    else
+      raise(Puppet::Error, 'Ini_settings only support collecting instances when a file path is hard coded')
+    end
+  end
+
   def exists?
     ini_file.get_value(section, setting)
   end
@@ -36,7 +58,11 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   end
 
   def file_path
-    resource[:path]
+    if self.class.respond_to?(:file_path)
+      self.class.file_path
+    else
+      resource[:path]
+    end
   end
 
   def separator

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -23,6 +23,14 @@ module Util
       @section_names
     end
 
+    def get_settings(section_name)
+      section = @sections_hash[section_name]
+      section.setting_names.inject({}) do |result, setting|
+        result[setting] = section.get_value(setting)
+        result
+      end
+    end
+
     def get_value(section_name, setting)
       if (@sections_hash.has_key?(section_name))
         @sections_hash[section_name].get_value(setting)

--- a/lib/puppet/util/ini_file/section.rb
+++ b/lib/puppet/util/ini_file/section.rb
@@ -32,6 +32,10 @@ class IniFile
       @end_line.nil?
     end
 
+    def setting_names
+      @existing_settings.keys | @additional_settings.keys
+    end
+
     def get_value(setting_name)
       @existing_settings[setting_name] || @additional_settings[setting_name]
     end


### PR DESCRIPTION
This commit adds purging to ini file native types.

Purging will only work for child providers that
implement the method: self.file_path. This is
because collecting all instances of the type (
which is a requirement for purging) is only possible
when the path of the file that is being managed
can be accessed by the class instance (in the
method self.instances.)

This commit adds the following method to the internal
of the ini_file:
- get_settings - has of all settings/values for
  a given section

It also adds the following method to the section
class:
- setting_names - list of all setting names in a
  section.

These methods are required for the instances method
to be able to list the values for all settings of
each section.
