### PR TITLE
Set the default indentation to 0

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -175,7 +175,7 @@ module Util
     def read_section(name, start_line, line_iter)
       settings = {}
       end_line_num = nil
-      min_indentation = nil
+      min_indentation = 0
       while true
         line, line_num = line_iter.peek
         if (line_num.nil? or match = SECTION_REGEX.match(line))


### PR DESCRIPTION
Hi,

A default of nil was causing problems with values when
they were commented out and didn't have a uncommented version
https://bugzilla.redhat.com/show_bug.cgi?id=903719

thanks,
Derek.
