### PR TITLE
Fix the key_val_setting parameter

### DIFF
--- a/tests/ini_setting.pp
+++ b/tests/ini_setting.pp
@@ -11,7 +11,7 @@ ini_setting { "sample setting2":
   section             => 'bar',
   setting             => 'barsetting',
   value               => 'BAR!',
-  key_value_separator => '=',
+  key_val_separator   => '=',
   ensure              => present,
   require             => Ini_setting["sample setting"],
 }


### PR DESCRIPTION
Previously the tests/ini_setting.pp had a syntax error. This fixes the problem as discovered by Niko Janceski deathanchor@gmail.com during Fundamentals training.
