### PR TITLE
Added 'ini_subsetting' custom resource type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,21 @@ individual setting in an INI file.  Here's an example usage:
       ensure  => present,
     }
 
+A supplementary resource type is `ini_subsetting`, which is used to manage
+settings that consist of several arguments such as
+
+    JAVA_ARGS="-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof "
+
+    ini_subsetting {'sample subsetting':
+      ensure  => present,
+      section => '',
+      key_val_separator => '=',
+      path => '/etc/default/pe-puppetdb',
+      setting => 'JAVA_ARGS',
+      subsetting => '-Xmx',
+      value   => '512m',
+    }
+
 A few noteworthy features:
 
  * The module tries *hard* not to manipulate your file any more than it needs to.

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -1,0 +1,70 @@
+require File.expand_path('../../../util/ini_file', __FILE__)
+require File.expand_path('../../../util/setting_value', __FILE__)
+
+Puppet::Type.type(:ini_subsetting).provide(:ruby) do
+
+  def exists?
+    setting_value.get_subsetting_value(subsetting)
+  end
+
+  def create
+    setting_value.add_subsetting(subsetting, resource[:value])
+    ini_file.set_value(section, setting, setting_value.get_value)
+    ini_file.save
+    @ini_file = nil
+    @setting_value = nil
+  end
+
+  def destroy
+    setting_value.remove_subsetting(subsetting)
+    ini_file.set_value(section, setting, setting_value.get_value)
+    ini_file.save
+    @ini_file = nil
+    @setting_value = nil
+  end
+
+  def value
+    setting_value.get_subsetting_value(subsetting)
+  end
+
+  def value=(value)
+    setting_value.add_subsetting(subsetting, resource[:value])
+    ini_file.set_value(section, setting, setting_value.get_value)
+    ini_file.save
+  end
+
+  def section
+    resource[:section]
+  end
+
+  def setting
+    resource[:setting]
+  end
+
+  def subsetting
+    resource[:subsetting]
+  end
+
+  def subsetting_separator
+    resource[:subsetting_separator]
+  end
+
+  def file_path
+    resource[:path]
+  end
+
+  def separator
+    resource[:key_val_separator] || '='
+  end
+
+  private
+  def ini_file
+    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator)
+  end
+
+  private
+  def setting_value
+    @setting_value ||= Puppet::Util::SettingValue.new(ini_file.get_value(section, setting), subsetting_separator)
+  end
+
+end

--- a/lib/puppet/type/ini_subsetting.rb
+++ b/lib/puppet/type/ini_subsetting.rb
@@ -1,0 +1,55 @@
+Puppet::Type.newtype(:ini_subsetting) do
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:section) do
+    desc 'The name of the section in the ini file in which the setting should be defined.'
+  end
+
+  newparam(:setting) do
+    desc 'The name of the setting to be defined.'
+  end
+
+  newparam(:subsetting) do
+    desc 'The name of the subsetting to be defined.'
+  end
+
+  newparam(:subsetting_separator) do
+    desc 'The separator string between subsettings. Defaults to " "'
+    defaultto(" ")
+  end
+
+  newparam(:path) do
+    desc 'The ini file Puppet will ensure contains the specified setting.'
+    validate do |value|
+      unless (Puppet.features.posix? and value =~ /^\//) or (Puppet.features.microsoft_windows? and (value =~ /^.:\// or value =~ /^\/\/[^\/]+\/[^\/]+/))
+        raise(Puppet::Error, "File paths must be fully qualified, not '#{value}'")
+      end
+    end
+  end
+
+  newparam(:key_val_separator) do
+    desc 'The separator string to use between each setting name and value. ' +
+        'Defaults to " = ", but you could use this to override e.g. whether ' +
+        'or not the separator should include whitespace.'
+    defaultto(" = ")
+
+    validate do |value|
+      unless value.scan('=').size == 1
+        raise Puppet::Error, ":key_val_separator must contain exactly one = character."
+      end
+    end
+  end
+
+  newproperty(:value) do
+    desc 'The value of the subsetting to be defined.'
+  end
+
+end

--- a/lib/puppet/util/setting_value.rb
+++ b/lib/puppet/util/setting_value.rb
@@ -1,0 +1,74 @@
+module Puppet
+module Util
+
+  class SettingValue
+  
+    def initialize(setting_value, subsetting_separator = ' ')
+      @setting_value = setting_value
+      @subsetting_separator = subsetting_separator
+      
+      if @setting_value
+        unquoted = setting_value[1, setting_value.length - 2]
+        @subsetting_items = unquoted.scan(Regexp.new("(?:(?:[^\\#{@subsetting_separator}]|\\.)+)"))  # an item can contain escaped separator
+        @subsetting_items.map! { |item| item.strip }
+      else
+      	@subsetting_items = []        
+      end     
+    end
+
+    def get_value
+    
+      result = ""
+      first = true
+      
+      @subsetting_items.each { |item|
+        result << @subsetting_separator unless first
+        result << item        
+        first = false
+      }
+      
+      "\"" + result + "\""
+    end
+
+    def get_subsetting_value(subsetting)
+    
+      value = nil
+      
+      @subsetting_items.each { |item|
+        if(item.start_with?(subsetting))
+          value = item[subsetting.length, item.length - subsetting.length]
+          break
+        end
+      }
+      
+      value
+    end
+    
+    def add_subsetting(subsetting, subsetting_value)
+    
+      new_item = subsetting + (subsetting_value || '')
+      found = false
+
+      @subsetting_items.map! { |item|
+        if item.start_with?(subsetting)
+          value = new_item
+          found = true
+        else
+          value = item
+        end
+        
+        value
+      }
+      
+      unless found
+        @subsetting_items.push(new_item)
+      end
+    end
+
+    def remove_subsetting(subsetting)   
+      @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting) ? nil : item }.compact
+    end
+    
+  end
+end
+end

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'puppet'
+
+provider_class = Puppet::Type.type(:ini_subsetting).provider(:ruby)
+describe provider_class do
+  include PuppetlabsSpec::Files
+
+  let(:tmpfile) { tmpfilename("ini_setting_test") }
+
+  let(:common_params) { {
+      :title    => 'ini_setting_ensure_present_test',
+      :path     => tmpfile,
+      :section  => '',
+      :key_val_separator => '=',
+      :setting => 'JAVA_ARGS',
+  } }
+
+  def validate_file(expected_content,tmpfile = tmpfile)
+    File.read(tmpfile).should == expected_content
+  end
+
+
+  before :each do
+    File.open(tmpfile, 'w') do |fh|
+      fh.write(orig_content)
+    end
+  end
+
+  context "when ensuring that a subsetting is present" do
+    let(:orig_content) {
+      <<-EOS
+JAVA_ARGS="-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof"
+      EOS
+    }
+
+    it "should add a missing subsetting" do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(
+         :subsetting => '-Xms', :value => '128m'))
+      provider = described_class.new(resource)
+      provider.exists?.should be_nil
+      provider.create
+      validate_file(<<-EOS
+JAVA_ARGS="-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof -Xms128m"
+      EOS
+)
+    end
+
+    it "should remove an existing subsetting" do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(
+          :subsetting => '-Xmx'))
+      provider = described_class.new(resource)
+      provider.exists?.should == "192m"
+      provider.destroy
+      validate_file(<<-EOS
+JAVA_ARGS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof"
+      EOS
+)
+    end
+    
+    it "should modify an existing subsetting" do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(
+          :subsetting => '-Xmx', :value => '256m'))
+      provider = described_class.new(resource)
+      provider.exists?.should == "192m"
+      provider.value=('256m')
+      validate_file(<<-EOS
+JAVA_ARGS="-Xmx256m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof"
+      EOS
+)
+    end
+    
+  end
+end

--- a/spec/unit/puppet/util/setting_value_spec.rb
+++ b/spec/unit/puppet/util/setting_value_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'puppet/util/setting_value'
+
+describe Puppet::Util::SettingValue do
+
+  describe "space subsetting separator" do
+    INIT_VALUE_SPACE = "\"-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof\""
+
+    before :each do
+      @setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_SPACE, " ")
+    end
+  
+    it "should get the original value" do
+      @setting_value.get_value.should == INIT_VALUE_SPACE
+    end
+   
+    it "should get the correct value" do
+      @setting_value.get_subsetting_value("-Xmx").should == "192m"
+    end
+  
+    it "should add a new value" do
+      @setting_value.add_subsetting("-Xms", "256m")
+      @setting_value.get_subsetting_value("-Xms").should == "256m"
+      @setting_value.get_value.should == INIT_VALUE_SPACE[0, INIT_VALUE_SPACE.length - 1] + " -Xms256m\""
+    end
+  
+    it "should change existing value" do
+      @setting_value.add_subsetting("-Xmx", "512m")
+      @setting_value.get_subsetting_value("-Xmx").should == "512m"
+    end
+  
+    it "should remove existing value" do
+      @setting_value.remove_subsetting("-Xmx")
+      @setting_value.get_subsetting_value("-Xmx").should == nil
+    end
+  end
+
+  describe "comma subsetting separator" do
+    INIT_VALUE_COMMA = "\"-Xmx192m,-XX:+HeapDumpOnOutOfMemoryError,-XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof\""
+
+    before :each do
+      @setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_COMMA, ",")
+    end
+  
+    it "should get the original value" do
+      @setting_value.get_value.should == INIT_VALUE_COMMA
+    end
+   
+    it "should get the correct value" do
+      @setting_value.get_subsetting_value("-Xmx").should == "192m"
+    end
+  
+    it "should add a new value" do
+      @setting_value.add_subsetting("-Xms", "256m")
+      @setting_value.get_subsetting_value("-Xms").should == "256m"
+      @setting_value.get_value.should == INIT_VALUE_COMMA[0, INIT_VALUE_COMMA.length - 1] + ",-Xms256m\""
+    end
+  
+    it "should change existing value" do
+      @setting_value.add_subsetting("-Xmx", "512m")
+      @setting_value.get_subsetting_value("-Xmx").should == "512m"
+    end
+  
+    it "should remove existing value" do
+      @setting_value.remove_subsetting("-Xmx")
+      @setting_value.get_subsetting_value("-Xmx").should == nil
+    end
+  end
+end

--- a/tests/ini_subsetting.pp
+++ b/tests/ini_subsetting.pp
@@ -1,0 +1,19 @@
+ini_subsetting {'sample subsetting':
+  ensure  => present,
+  section => '',
+  key_val_separator => '=',
+  path => '/etc/default/pe-puppetdb',
+  setting => 'JAVA_ARGS',
+  subsetting => '-Xmx',
+  value   => '512m',
+}
+
+ini_subsetting {'sample subsetting2':
+  ensure  => absent,
+  section => '',
+  key_val_separator => '=',
+  path => '/etc/default/pe-puppetdb',
+  setting => 'JAVA_ARGS',
+  subsetting => '-Xms',
+}
+    


### PR DESCRIPTION
for handling settings which have more arguments such as

JAVA_ARGS="-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof "

If you're ok with this approach I can add some rspec tests.
