### PR TITLE
guard against nil indentation values

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -256,7 +256,7 @@ module Util
     def insert_inline_setting_line(result, section, setting, value)
       line_num = result[:line_num]
       match = result[:match]
-      lines.insert(line_num + 1, "#{' ' * section.indentation}#{setting}#{match[4]}#{value}")
+      lines.insert(line_num + 1, "#{' ' * (section.indentation || 0 )}#{setting}#{match[4]}#{value}")
     end
 
     # Utility method; given a section index (index into the @section_names

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -809,6 +809,46 @@ blah = blah
       )
     end
 
+    context 'when a section only contains comments' do
+     let(:orig_content) {
+      <<-EOS
+[section1]
+# foo=foovalue
+# bar=bar2
+EOS
+    }
+      it 'should be able to add a new setting when a section contains only comments' do
+        resource = Puppet::Type::Ini_setting.new(
+          common_params.merge(:section => 'section1', :setting => 'foo', :value => 'foovalue2')
+        )
+        provider = described_class.new(resource)
+        provider.exists?.should be_false
+        provider.create
+        validate_file(<<-EOS
+[section1]
+# foo=foovalue
+foo=foovalue2
+# bar=bar2
+        EOS
+        )
+      end
+      it 'should be able to add a new setting when it matches a commented out line other than the first one' do
+        resource = Puppet::Type::Ini_setting.new(
+          common_params.merge(:section => 'section1', :setting => 'bar', :value => 'barvalue2')
+        )
+        provider = described_class.new(resource)
+        provider.exists?.should be_false
+        provider.create
+        validate_file(<<-EOS
+[section1]
+# foo=foovalue
+# bar=bar2
+bar=barvalue2
+        EOS
+        )
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This commit is intended to resolves an issue where the indentation
value can be nil (which leads to a run time exception)

This occurrs in cases where a section is following by only one of more
comments.

The proposed fix is to guard against potential nil values where the
error occurs. This fix is idential to code used at line 125 of the same file.
