### PR TITLE
fix the PUPPET_GEM_VERSION pessimism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,22 @@ rvm:
   - 1.9.3
   - ruby-head
 env:
-  - PUPPET_GEM_VERSION="~> 2.6"
-  - PUPPET_GEM_VERSION="~> 2.7"
-  - PUPPET_GEM_VERSION="~> 3.0"
-  - PUPPET_GEM_VERSION="~> 3.1"
+  - PUPPET_GEM_VERSION="~> 2.6.0"
+  - PUPPET_GEM_VERSION="~> 2.7.0"
+  - PUPPET_GEM_VERSION="~> 3.0.0"
+  - PUPPET_GEM_VERSION="~> 3.1.0"
+  - PUPPET_GEM_VERSION="~> 3.2.0"
 matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7"
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.7"
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.6"
+      env: PUPPET_GEM_VERSION="~> 2.6.0"
     - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.6"
+      env: PUPPET_GEM_VERSION="~> 2.6.0"
 notifications:
   email: false


### PR DESCRIPTION
This was actually matching 2.x and 3.x, you need the extra version number
component for the semantics to mean 2.6.x, 2.7.x, 3.0.x, and 3.1.x

Also add version 3.2.x
