### PR TITLE
Properly handle empty values

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -6,8 +6,8 @@ module Util
   class IniFile
 
     @@SECTION_REGEX = /^\s*\[([\w\d\.\\\/\-\:]+)\]\s*$/
-    @@SETTING_REGEX = /^(\s*)([\w\d\.\\\/\-]+)(\s*=\s*)([\S\s]*\S)\s*$/
-    @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([\w\d\.\\\/\-]+)(\s*=\s*)([\S\s]*\S)\s*$/
+    @@SETTING_REGEX = /^(\s*)([\w\d\.\\\/\-]+)([ \t]*=[ \t]*)([\S\s]*?)\s*$/
+    @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([\w\d\.\\\/\-]+)([ \t]*=[ \t]*)([\S\s]*?)\s*$/
 
     def initialize(path, key_val_separator = ' = ')
       @path = path

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -834,6 +834,7 @@ subby=bar
 # foo = foovalue
 ;bar=barvalue
 blah = blah
+#baz=
       EOS
     }
 
@@ -854,6 +855,7 @@ blah = blah
 foo = foo3
 ;bar=barvalue
 blah = blah
+#baz=
       EOS
       )
     end
@@ -874,6 +876,7 @@ blah = blah
 # foo = foovalue
 ;bar=barvalue
 blah = blah
+#baz=
       EOS
       )
     end
@@ -895,6 +898,29 @@ blah = blah
 ;bar=barvalue
 bar=bar3
 blah = blah
+#baz=
+      EOS
+      )
+    end
+
+    it "should add a new setting below an empty commented version of that setting" do
+      resource = Puppet::Type::Ini_setting.new(
+          common_params.merge(:section => 'section2', :setting => 'baz', :value => 'bazvalue'))
+      provider = described_class.new(resource)
+      provider.exists?.should be_false
+      provider.create
+      validate_file(<<-EOS
+     [section1]
+     # foo=foovalue
+     bar=barvalue
+     foo = foovalue2
+
+[section2]
+# foo = foovalue
+;bar=barvalue
+blah = blah
+#baz=
+baz=bazvalue
       EOS
       )
     end

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'stringio'
 require 'puppet/util/ini_file'
 
 describe Puppet::Util::IniFile do
@@ -20,6 +21,7 @@ describe Puppet::Util::IniFile do
 foo=foovalue
 
 bar = barvalue
+baz =
 [section2]
 
 foo= foovalue2
@@ -44,6 +46,7 @@ baz=bazvalue
     it "should expose settings for sections" do
       subject.get_value("section1", "foo").should == "foovalue"
       subject.get_value("section1", "bar").should == "barvalue"
+      subject.get_value("section1", "baz").should == ""
       subject.get_value("section2", "foo").should == "foovalue2"
       subject.get_value("section2", "baz").should == "bazvalue"
       subject.get_value("section2", "zot").should == "multi word value"
@@ -102,6 +105,34 @@ foo=foovalue
       subject.get_value("", "foo").should == "bar"
       subject.get_value("section1", "foo").should == "foovalue"
     end
+  end
 
+  context "when updating a file with existing empty values" do
+    let(:sample_content) {
+      template = <<-EOS
+[section1]
+foo=
+#bar=
+      EOS
+      template.split("\n")
+    }
+
+    it "should properly update uncommented values" do
+      subject.get_value("section1", "far").should == nil
+      subject.set_value("section1", "foo", "foovalue")
+      subject.get_value("section1", "foo").should == "foovalue"
+    end
+
+    it "should properly update commented values" do
+      subject.get_value("section1", "bar").should == nil
+      subject.set_value("section1", "bar", "barvalue")
+      subject.get_value("section1", "bar").should == "barvalue"
+    end
+
+    it "should properly add new empty values" do
+      subject.get_value("section1", "baz").should == nil
+      subject.set_value("section1", "baz", "bazvalue")
+      subject.get_value("section1", "baz").should == "bazvalue"
+    end
   end
 end


### PR DESCRIPTION
It is a legitimate use case to set empty values; to override a
default when an empty value is acceptable for instance. This patch
changes the regex in three ways: it 1) removes the requirement for
a non-whitespace terminator on a setting value, 2) makes the value
match non-greedy so that the \s_$ at the end can catch the newline
and 3) changes the \s_=\s\* to [ \t]_=[ \t]_ because we don't want
that to capture _any_ whitespace (like a newline).
