### PR TITLE
Support spaces in sections

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -5,7 +5,7 @@ module Puppet
 module Util
   class IniFile
 
-    @@SECTION_REGEX = /^\s*\[([\s\w\d\.\\\/\-\:]+)\]\s*$/
+    @@SECTION_REGEX = /^\s*\[([\w\d\.\\\/\-\:\s]*[\w\d\.\\\/\-])\]\s*$/
     @@SETTING_REGEX = /^(\s*)([\w\d\.\\\/\-\s]*[\w\d\.\\\/\-])([ \t]*=[ \t]*)([\S\s]*?)\s*$/
     @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([\w\d\.\\\/\-]+)([ \t]*=[ \t]*)([\S\s]*?)\s*$/
 

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -965,6 +965,58 @@ bar=barvalue2
       end
     end
 
+    context "when sections have spaces and dashes" do
+      let(:orig_content) {
+        <<-EOS
+# This is a comment
+[section - one]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section - two]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+        EOS
+      }
+
+      it "should add a missing setting to the correct section" do
+        resource = Puppet::Type::Ini_setting.new(common_params.merge(
+            :section => 'section - two', :setting => 'yahoo', :value => 'yippee'))
+        provider = described_class.new(resource)
+        provider.exists?.should be_nil
+        provider.create
+        validate_file(<<-EOS
+# This is a comment
+[section - one]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section - two]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+yahoo = yippee
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+        EOS
+  )
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
Needed for Splunk saved searches.

```
[bad things on web hosts]
request.ui_dispatch_view = flashtimeline
search = index=production host=web* AND "bad thing"
```
