### PR TITLE
Adding whitespace capability to section header regex

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -5,7 +5,7 @@ module Puppet
 module Util
   class IniFile
 
-    @@SECTION_REGEX = /^\s*\[([\w\d\.\\\/\-\:]+)\]\s*$/
+    @@SECTION_REGEX = /^\s*\[([\s\w\d\.\\\/\-\:]+)\]\s*$/
     @@SETTING_REGEX = /^(\s*)([\w\d\.\\\/\-\s]*[\w\d\.\\\/\-])([ \t]*=[ \t]*)([\S\s]*?)\s*$/
     @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([\w\d\.\\\/\-]+)([ \t]*=[ \t]*)([\S\s]*?)\s*$/
 


### PR DESCRIPTION
Change supports section headers containing whitespace.
