### PR TITLE
introduce create_ini_settings

### DIFF
--- a/lib/puppet/parser/functions/create_ini_settings.rb
+++ b/lib/puppet/parser/functions/create_ini_settings.rb
@@ -1,0 +1,86 @@
+#
+# create_ini_settings.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:create_ini_settings, :type => :statement, :doc => <<-EOS
+Uses create_resources to create a set of ini_setting resources from a hash:
+
+    $settings = {  section1 => {
+        setting1 => val1
+      },
+      section2 => {
+        setting2 => val2,
+        setting3 => {
+          ensure => absent
+        }
+      }
+    }
+    $defaults = {
+      path => '/tmp/foo.ini'
+    }
+    create_ini_settings($settings,$defaults)
+
+
+Will create the following resources
+
+    ini_setting{'[section1] setting1':
+      ensure  => present,
+      section => 'section1',
+      setting => 'setting1',
+      value   => 'val1',
+      path    => '/tmp/foo.ini',
+    }
+    ini_setting{'[section2] setting2':
+      ensure  => present,
+      section => 'section2',
+      setting => 'setting2',
+      value   => 'val2',
+      path    => '/tmp/foo.ini',
+    }
+    ini_setting{'[section2] setting3':
+      ensure  => absent,
+      section => 'section2',
+      setting => 'setting3',
+      path    => '/tmp/foo.ini',
+    }
+
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "create_ini_settings(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1 or 2)") unless arguments.size.between?(1,2)
+
+    settings = arguments[0]
+    defaults = arguments[1] || {}
+
+    if [settings,defaults].any?{|i| !i.is_a?(Hash) }
+      raise(Puppet::ParseError,
+        'create_ini_settings(): Requires all arguments to be a Hash')
+    end
+
+    resources = settings.keys.inject({}) do |res, section|
+      raise(Puppet::ParseError,
+        "create_ini_settings(): Section #{section} must contain a Hash") \
+        unless settings[section].is_a?(Hash)
+
+      settings[section].each do |setting, value|
+        res["[#{section}] #{setting}"] = {
+          'ensure'  => 'present',
+          'section' => section,
+          'setting' => setting,
+        }.merge(if value.is_a?(Hash)
+          value
+        else
+          { 'value'   => value, }
+        end)
+      end
+      res
+    end
+
+    Puppet::Parser::Functions.function('create_resources')
+    function_create_resources(['ini_setting',resources,defaults])
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/classes/create_ini_settings_test_spec.rb
+++ b/spec/classes/create_ini_settings_test_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+# end-to-end test of the create_init_settings function
+describe 'create_ini_settings_test' do
+  it { should have_ini_setting_resource_count(3) }
+  it { should contain_ini_setting('[section1] setting1').with(
+    :ensure  => 'present',
+    :section => 'section1',
+    :setting => 'setting1',
+    :value   => 'val1',
+    :path    => '/tmp/foo.ini'
+  )}
+  it { should contain_ini_setting('[section2] setting2').with(
+    :ensure  => 'present',
+    :section => 'section2',
+    :setting => 'setting2',
+    :value   => 'val2',
+    :path    => '/tmp/foo.ini'
+  )}
+  it { should contain_ini_setting('[section2] setting3').with(
+    :ensure  => 'absent',
+    :section => 'section2',
+    :setting => 'setting3',
+    :path    => '/tmp/foo.ini'
+  )}
+end

--- a/spec/fixtures/modules/create_ini_settings_test/manifests/init.pp
+++ b/spec/fixtures/modules/create_ini_settings_test/manifests/init.pp
@@ -1,0 +1,17 @@
+# simple test class
+class create_ini_settings_test {
+  $settings = {  section1 => {
+      setting1 => val1
+    },
+    section2 => {
+      setting2 => val2,
+      setting3 => {
+        ensure => absent
+      }
+    }
+  }
+  $defaults = {
+    path => '/tmp/foo.ini'
+  }
+  create_ini_settings($settings,$defaults)
+}

--- a/spec/functions/create_ini_settings_spec.rb
+++ b/spec/functions/create_ini_settings_spec.rb
@@ -1,0 +1,26 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+require 'rspec-puppet'
+
+describe 'create_ini_settings' do
+  before :each do
+    Puppet::Parser::Functions.autoloader.loadall
+    Puppet::Parser::Functions.function(:create_resources)
+  end
+
+  describe 'argument handling' do
+    it { should run.with_params.and_raise_error(Puppet::ParseError, /0 for 1 or 2/) }
+    it { should run.with_params(1,2,3).and_raise_error(Puppet::ParseError, /3 for 1 or 2/) }
+    it { should run.with_params('foo').and_raise_error(Puppet::ParseError, /Requires all arguments/) }
+    it { should run.with_params({},'foo').and_raise_error(Puppet::ParseError, /Requires all arguments/) }
+
+    it { should run.with_params({}) }
+    it { should run.with_params({},{}) }
+
+    it { should run.with_params({ 1 => 2 }).and_raise_error(Puppet::ParseError, /Section 1 must contain a Hash/) }
+  end
+
+  context 'given a catalog with puppet package => absent' do
+  end
+end

--- a/spec/functions/create_ini_settings_spec.rb
+++ b/spec/functions/create_ini_settings_spec.rb
@@ -20,7 +20,4 @@ describe 'create_ini_settings' do
 
     it { should run.with_params({ 1 => 2 }).and_raise_error(Puppet::ParseError, /Section 1 must contain a Hash/) }
   end
-
-  context 'given a catalog with puppet package => absent' do
-  end
 end


### PR DESCRIPTION
create_ini_settings is a function that allows you to create
ini_setting resources from a simple hash:

    $settings = {  section1 => {
        setting1 => val1
      },
      section2 => {
        setting2 => val2,
        setting3 => {
          ensure => absent
        }
      }
    }
    $defaults = {
      path => '/tmp/foo.ini'
    }
    create_ini_settings($settings,$defaults)

Will create the following resources

    ini_setting{'[section1] setting1':
      ensure  => present,
      section => 'section1',
      setting => 'setting1',
      value   => 'val1',
      path    => '/tmp/foo.ini',
    }
    ini_setting{'[section2] setting2':
      ensure  => present,
      section => 'section2',
      setting => 'setting2',
      value   => 'val2',
      path    => '/tmp/foo.ini',
    }
    ini_setting{'[section2] setting3':
      ensure  => absent,
      section => 'section2',
      setting => 'setting3',
      path    => '/tmp/foo.ini',
    }

This allows one to create much easier classes
that should be able to manage an arbritary set of
ini-style settings without having to specify each
one of them.