### PR TITLE
Support curly braces in setting names

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -6,7 +6,7 @@ module Util
   class IniFile
 
     @@SECTION_REGEX = /^\s*\[([^\]]*)\]\s*$/
-    @@SETTING_REGEX = /^(\s*)([^\[#;][\w\d\.\\\/\-\s\[\]\']*[\w\d\.\\\/\-\]])([ \t]*=[ \t]*)([\S\s]*?)\s*$/
+    @@SETTING_REGEX = /^(\s*)([^\[#;][\w\d\.\\\/\-\s\[\]\'\{\}]*[\w\d\.\\\/\-\]\{\}])([ \t]*=[ \t]*)([\S\s]*?)\s*$/
     @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([^\[]*[\w\d\.\\\/\-]+[\w\d\.\\\/\-\[\]\']+)([ \t]*=[ \t]*)([\S\s]*?)\s*$/
 
     def initialize(path, key_val_separator = ' = ')


### PR DESCRIPTION
Add support for curly braces in setting names.

This allows for manipulating KDE INI files, where one can find settings such as:

```
{d03619b6-9b3c-48cc-9d9c-a2aadb485550}=Search,none,Search
```
