### PR TITLE
Feature: Subsetting val separator

### DIFF
--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -4,11 +4,11 @@ require File.expand_path('../../../util/setting_value', __FILE__)
 Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def exists?
-    setting_value.get_subsetting_value(subsetting)
+    setting_value.get_subsetting_value(subsetting, subsetting_val_separator)
   end
 
   def create
-    setting_value.add_subsetting(subsetting, resource[:value])
+    setting_value.add_subsetting(subsetting, subsetting_val_separator, resource[:value])
     ini_file.set_value(section, setting, setting_value.get_value)
     ini_file.save
     @ini_file = nil
@@ -16,7 +16,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   end
 
   def destroy
-    setting_value.remove_subsetting(subsetting)
+    setting_value.remove_subsetting(subsetting, subsetting_val_separator)
     ini_file.set_value(section, setting, setting_value.get_value)
     ini_file.save
     @ini_file = nil
@@ -24,11 +24,11 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   end
 
   def value
-    setting_value.get_subsetting_value(subsetting)
+    setting_value.get_subsetting_value(subsetting, subsetting_val_separator)
   end
 
   def value=(value)
-    setting_value.add_subsetting(subsetting, resource[:value])
+    setting_value.add_subsetting(subsetting, subsetting_val_separator, resource[:value])
     ini_file.set_value(section, setting, setting_value.get_value)
     ini_file.save
   end
@@ -55,6 +55,10 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def separator
     resource[:key_val_separator] || '='
+  end
+
+  def subsetting_val_separator
+    resource[:subsetting_val_separator] || ''
   end
 
   def quote_char

--- a/lib/puppet/type/ini_subsetting.rb
+++ b/lib/puppet/type/ini_subsetting.rb
@@ -47,6 +47,12 @@ Puppet::Type.newtype(:ini_subsetting) do
       end
     end
   end
+  
+  newparam(:subsetting_val_separator) do
+    desc 'The separator string to us between each subsetting name and value. ' +
+         'defaults to "".'
+    defaultto("")
+  end  
 
   newparam(:quote_char) do
     desc 'The character used to quote the entire value of the setting. ' +

--- a/lib/puppet/util/setting_value.rb
+++ b/lib/puppet/util/setting_value.rb
@@ -3,7 +3,7 @@ module Util
 
   class SettingValue
 
-    def initialize(setting_value, subsetting_separator = ' ', default_quote_char = nil)
+    def initialize(setting_value, subsetting_separator = ' ', subsetting_val_separator = '', default_quote_char = nil)
       @setting_value = setting_value
       @subsetting_separator = subsetting_separator
 
@@ -51,13 +51,14 @@ module Util
       @quote_char + result + @quote_char
     end
 
-    def get_subsetting_value(subsetting)
+    def get_subsetting_value(subsetting, val_separator)
     
       value = nil
       
       @subsetting_items.each { |item|
-        if(item.start_with?(subsetting))
-          value = item[subsetting.length, item.length - subsetting.length]
+        subsetting_and_val_separator = subsetting+val_separator
+        if(item.start_with?(subsetting_and_val_separator))
+          value = item[subsetting_and_val_separator.length, item.length - subsetting_and_val_separator.length]
           break
         end
       }
@@ -65,13 +66,13 @@ module Util
       value
     end
     
-    def add_subsetting(subsetting, subsetting_value)
+    def add_subsetting(subsetting, val_separator, subsetting_value)
     
-      new_item = subsetting + (subsetting_value || '')
+      new_item = subsetting + (val_separator || '') + (subsetting_value || '')
       found = false
 
       @subsetting_items.map! { |item|
-        if item.start_with?(subsetting)
+        if item.start_with?(subsetting+val_separator)
           value = new_item
           found = true
         else
@@ -86,8 +87,8 @@ module Util
       end
     end
 
-    def remove_subsetting(subsetting)   
-      @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting) ? nil : item }.compact
+    def remove_subsetting(subsetting, val_separator)   
+      @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting+val_separator) ? nil : item }.compact
     end
     
   end

--- a/spec/unit/puppet/util/setting_value_spec.rb
+++ b/spec/unit/puppet/util/setting_value_spec.rb
@@ -15,24 +15,25 @@ describe Puppet::Util::SettingValue do
     end
    
     it "should get the correct value" do
-      @setting_value.get_subsetting_value("-Xmx").should == "192m"
+      @setting_value.get_subsetting_value("-Xmx",'').should == "192m"
     end
   
     it "should add a new value" do
-      @setting_value.add_subsetting("-Xms", "256m")
-      @setting_value.get_subsetting_value("-Xms").should == "256m"
+      @setting_value.add_subsetting("-Xms", '', "256m")
+      @setting_value.get_subsetting_value("-Xms",'').should == "256m"
       @setting_value.get_value.should == INIT_VALUE_SPACE[0, INIT_VALUE_SPACE.length - 1] + " -Xms256m\""
     end
   
     it "should change existing value" do
-      @setting_value.add_subsetting("-Xmx", "512m")
-      @setting_value.get_subsetting_value("-Xmx").should == "512m"
+      @setting_value.add_subsetting("-Xmx", '', "512m")
+      @setting_value.get_subsetting_value("-Xmx",'').should == "512m"
     end
   
     it "should remove existing value" do
-      @setting_value.remove_subsetting("-Xmx")
-      @setting_value.get_subsetting_value("-Xmx").should == nil
+      @setting_value.remove_subsetting("-Xmx",'')
+      @setting_value.get_subsetting_value("-Xmx",'').should == nil
     end
+    
   end
 
   describe "comma subsetting separator" do
@@ -47,23 +48,23 @@ describe Puppet::Util::SettingValue do
     end
    
     it "should get the correct value" do
-      @setting_value.get_subsetting_value("-Xmx").should == "192m"
+      @setting_value.get_subsetting_value("-Xmx",'').should == "192m"
     end
   
     it "should add a new value" do
-      @setting_value.add_subsetting("-Xms", "256m")
-      @setting_value.get_subsetting_value("-Xms").should == "256m"
+      @setting_value.add_subsetting("-Xms", '', "256m")
+      @setting_value.get_subsetting_value("-Xms", '').should == "256m"
       @setting_value.get_value.should == INIT_VALUE_COMMA[0, INIT_VALUE_COMMA.length - 1] + ",-Xms256m\""
     end
   
     it "should change existing value" do
-      @setting_value.add_subsetting("-Xmx", "512m")
-      @setting_value.get_subsetting_value("-Xmx").should == "512m"
+      @setting_value.add_subsetting("-Xmx", '', "512m")
+      @setting_value.get_subsetting_value("-Xmx",'').should == "512m"
     end
   
     it "should remove existing value" do
-      @setting_value.remove_subsetting("-Xmx")
-      @setting_value.get_subsetting_value("-Xmx").should == nil
+      @setting_value.remove_subsetting("-Xmx",'')
+      @setting_value.get_subsetting_value("-Xmx",'').should == nil
     end
   end
 
@@ -72,32 +73,64 @@ describe Puppet::Util::SettingValue do
     INIT_VALUE_UNQUOTED = '-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof'
 
     it "should get quoted empty string if original value was empty" do
-      setting_value = Puppet::Util::SettingValue.new(nil, ' ', QUOTE_CHAR)
+      setting_value = Puppet::Util::SettingValue.new(nil, ' ', '', QUOTE_CHAR)
       setting_value.get_value.should == QUOTE_CHAR * 2
     end
    
     it "should quote the setting when adding a value" do
-      setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_UNQUOTED, ' ', QUOTE_CHAR)
-      setting_value.add_subsetting("-Xms", "256m")
+      setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_UNQUOTED, ' ', '', QUOTE_CHAR)
+      setting_value.add_subsetting("-Xms", '', "256m")
 
-      setting_value.get_subsetting_value("-Xms").should == "256m"
+      setting_value.get_subsetting_value("-Xms",'').should == "256m"
       setting_value.get_value.should == QUOTE_CHAR + INIT_VALUE_UNQUOTED + ' -Xms256m' + QUOTE_CHAR
     end
   
     it "should quote the setting when changing an existing value" do
-      setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_UNQUOTED, ' ', QUOTE_CHAR)
-      setting_value.add_subsetting("-Xmx", "512m")
+      setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_UNQUOTED, ' ', '', QUOTE_CHAR)
+      setting_value.add_subsetting("-Xmx", '', "512m")
 
-      setting_value.get_subsetting_value("-Xmx").should == "512m"
+      setting_value.get_subsetting_value("-Xmx",'').should == "512m"
       setting_value.get_value.should =~ /^#{Regexp.quote(QUOTE_CHAR)}.*#{Regexp.quote(QUOTE_CHAR)}$/
     end
   
     it "should quote the setting when removing an existing value" do
-      setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_UNQUOTED, ' ', QUOTE_CHAR)
-      setting_value.remove_subsetting("-Xmx")
+      setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_UNQUOTED, ' ', '', QUOTE_CHAR)
+      setting_value.remove_subsetting("-Xmx",'')
 
-      setting_value.get_subsetting_value("-Xmx").should == nil
+      setting_value.get_subsetting_value("-Xmx",'').should == nil
       setting_value.get_value.should =~ /^#{Regexp.quote(QUOTE_CHAR)}.*#{Regexp.quote(QUOTE_CHAR)}$/
+    end
+  end
+  
+  describe "subsetting_val_separator value separator" do
+    INIT_VALUE_VAL_SEP = "\"-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pe-puppetdb/puppetdb-oom.hprof\""
+
+    before :each do
+      @setting_value = Puppet::Util::SettingValue.new(INIT_VALUE_VAL_SEP, " ")
+    end
+
+    it "should get the original value" do
+      @setting_value.get_value.should == INIT_VALUE_VAL_SEP
+    end
+ 
+    it "should get a separated value" do 
+      @setting_value.get_subsetting_value("-XX:HeapDumpPath","=").should == "/var/log/pe-puppetdb/puppetdb-oom.hprof"
+    end
+
+    it "should add a new separated value" do 
+      @setting_value.add_subsetting('-XX:MaxPermGen', '=', '256m')
+      @setting_value.get_subsetting_value('-XX:MaxPermGen', '=').should == '256m'
+      @setting_value.get_value.should == INIT_VALUE_VAL_SEP[0, INIT_VALUE_VAL_SEP.length - 1] + " -XX:MaxPermGen=256m\""
+    end
+  
+    it "should change an existing separated value" do
+      @setting_value.add_subsetting("-XX:HeapDumpPath", "=", '/tmp/dumppath')
+      @setting_value.get_subsetting_value("-XX:HeapDumpPath", "=").should == '/tmp/dumppath'
+    end
+
+    it "should remove an existing separated value" do 
+      @setting_value.remove_subsetting("-XX:HeapDumpPath",'=')
+      @setting_value.get_subsetting_value("-XX:HeapDumpPath",'=').should == nil
     end
   end
 end

--- a/tests/ini_subsetting.pp
+++ b/tests/ini_subsetting.pp
@@ -20,7 +20,7 @@ ini_subsetting { 'sample subsetting2':
 ini_subsetting {'sample subsetting3':
   ensure                   => present,
   section                  => '',
-  key_val_seperator        => '=',
+  key_val_separator        => '=',
   path                     => '/etc/default/pe-puppetdb',
   setting                  => 'JAVA_ARGS',
   subsetting               => '-XX:MaxPermSize',

--- a/tests/ini_subsetting.pp
+++ b/tests/ini_subsetting.pp
@@ -16,3 +16,14 @@ ini_subsetting { 'sample subsetting2':
   setting           => 'JAVA_ARGS',
   subsetting        => '-Xms',
 }
+
+ini_subsetting {'sample subsetting3':
+  ensure                   => present,
+  section                  => '',
+  key_val_seperator        => '=',
+  path                     => '/etc/default/pe-puppetdb',
+  setting                  => 'JAVA_ARGS',
+  subsetting               => '-XX:MaxPermSize',
+  subsetting_val_separator => '=',
+  value                    => '256m',
+}


### PR DESCRIPTION
This feature does what key_val_separator does, but for individual subsettings. Allows better control of things like -XX:HeapDumpFile=<somevalue>, by treating -XX:HeapDumpFile as the subsetting, <somevalue> as the value and '=' as the subsetting_val_separator.

By default it maintains current behaviour by setting subsetting_val_separator to empty.