### PR TITLE
Don't manage Gemfile with modulesync

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,5 @@
 ---
 spec/spec_helper.rb:
   unmanaged: true
+Gemfile:
+  unmanaged: true


### PR DESCRIPTION
46ad0bf made changes to the Gemfile that can't be modeled in the
modulesync templates. This commit changes the Gemfile to be unmanaged
for the time being.