### PR TITLE
Add ability to specify a hash of ini_settings and ini_subsettings.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,7 @@
 fixtures:
+  repositories:
+    stdlib:
+      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+      ref: '4.6.0'
   symlinks:
     inifile: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,14 @@ def location_for(place, fake_version = nil)
 end
 
 group :development, :unit_tests do
-  gem 'rspec-core', '3.1.7',     :require => false
+  gem 'rake',                    :require => false
+  # rspec must be v2 for ruby 1.8.7
+  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+    gem 'rspec', '~> 2.0'
+  else
+    gem 'rspec-core', '3.1.7',     :require => false
+  end
+  gem 'rspec-puppet', '~> 1.0',  :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,46 @@
+# == Class: inifile
+#
+# Use create_resources() to allow the specification of ini_setting and
+# ini_subsetting entries.
+#
+class inifile (
+  $ini_settings                = undef,
+  $ini_subsettings             = undef,
+  $ini_settings_hiera_merge    = true,
+  $ini_subsettings_hiera_merge = true,
+) {
+
+  if is_string($ini_settings_hiera_merge) == true {
+    $ini_settings_hiera_merge_bool = str2bool($ini_settings_hiera_merge)
+  } else {
+    $ini_settings_hiera_merge_bool = $ini_settings_hiera_merge
+  }
+  validate_bool($ini_settings_hiera_merge_bool)
+
+  if is_string($ini_subsettings_hiera_merge) == true {
+    $ini_subsettings_hiera_merge_bool = str2bool($ini_subsettings_hiera_merge)
+  } else {
+    $ini_subsettings_hiera_merge_bool = $ini_subsettings_hiera_merge
+  }
+  validate_bool($ini_subsettings_hiera_merge_bool)
+
+  if $ini_settings != undef {
+    if $ini_settings_hiera_merge_bool == true {
+      $ini_settings_real = hiera_hash('inifile::ini_settings')
+    } else {
+      $ini_settings_real = $ini_settings
+    }
+    validate_hash($ini_settings_real)
+    create_resources('ini_setting',$ini_settings_real)
+  }
+
+  if $ini_subsettings != undef {
+    if $ini_subsettings_hiera_merge_bool == true {
+      $ini_subsettings_real = hiera_hash('inifile::ini_subsettings')
+    } else {
+      $ini_subsettings_real = $ini_subsettings
+    }
+    validate_hash($ini_subsettings_real)
+    create_resources('ini_subsetting',$ini_subsettings_real)
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -101,5 +101,8 @@
       "name": "puppet",
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }
+  ],
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+describe 'inifile' do
+
+  describe 'with default options' do
+    it { should compile.with_all_deps }
+    it { should contain_class('inifile') }
+  end
+
+  describe 'with parameter ini_settings_hiera_merge' do
+    context 'set to an invalid type (non-string and a non-boolean)' do
+      let(:params) { { :ini_settings_hiera_merge => ['invalid','type'] } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('inifile')
+        }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a boolean./)
+      end
+    end
+
+    ['true',true,'false',false].each do |value|
+      context "set to #{value}" do
+        let(:params) { { :ini_settings_hiera_merge => value } }
+
+        it { should contain_class('inifile') }
+      end
+    end
+  end
+
+  describe 'with parameter ini_settings' do
+    context 'set to an invalid type (non-hash)' do
+      let(:params) do
+        {
+          :ini_settings             => ['invalid','type'],
+          :ini_settings_hiera_merge => false,
+        }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('inifile')
+        }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a Hash./)
+      end
+    end
+
+    context 'set to a valid hash' do
+      let(:params) { { :ini_settings_hiera_merge => false,
+        :ini_settings => {
+        'sample setting' => {
+          'ensure'  => 'absent',
+          'path'    => '/tmp/foo.ini',
+          'section' => 'foo',
+          'setting' => 'foosetting',
+          'value'   => 'FOO!',
+        },
+        'colorize_git' => {
+          'ensure'  => 'present',
+          'path'    => '/root/.gitconfig',
+          'section' => 'color',
+          'setting' => 'ui',
+          'value'   => 'auto',
+        }
+      } } }
+
+      it { should contain_class('inifile') }
+
+      it {
+        should contain_ini_setting('sample setting').with({
+          'ensure'  => 'absent',
+          'path'    => '/tmp/foo.ini',
+          'section' => 'foo',
+          'setting' => 'foosetting',
+          'value'   => 'FOO!',
+        })
+      }
+
+      it {
+        should contain_ini_setting('colorize_git').with({
+          'ensure'  => 'present',
+          'path'    => '/root/.gitconfig',
+          'section' => 'color',
+          'setting' => 'ui',
+          'value'   => 'auto',
+        })
+      }
+    end
+  end
+
+  describe 'with parameter ini_subsettings_hiera_merge' do
+    context 'set to an invalid type (non-string and a non-boolean)' do
+      let(:params) { { :ini_subsettings_hiera_merge => ['invalid','type'] } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('inifile')
+        }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a boolean./)
+      end
+    end
+
+    ['true',true,'false',false].each do |value|
+      context "set to #{value}" do
+        let(:params) { { :ini_subsettings_hiera_merge => value } }
+
+        it { should contain_class('inifile') }
+      end
+    end
+  end
+
+  describe 'with parameter ini_subsettings' do
+    context 'set to an invalid type (non-hash)' do
+      let(:params) do
+        {
+          :ini_subsettings             => ['invalid','type'],
+          :ini_subsettings_hiera_merge => false,
+        }
+      end
+
+      it 'should fail' do
+        expect {
+          should contain_class('inifile')
+        }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a Hash./)
+      end
+    end
+
+    context 'set to a valid hash' do
+      let(:params) { { :ini_subsettings_hiera_merge => false,
+        :ini_subsettings => {
+        'sample setting' => {
+          'ensure'  => 'absent',
+          'path'    => '/tmp/foo.ini',
+          'section' => 'foo',
+          'setting' => 'foosetting',
+          'value'   => 'FOO!',
+        },
+        'colorize_git' => {
+          'ensure'  => 'present',
+          'path'    => '/root/.gitconfig',
+          'section' => 'color',
+          'setting' => 'ui',
+          'value'   => 'auto',
+        }
+      } } }
+
+      it { should contain_class('inifile') }
+
+      it {
+        should contain_ini_subsetting('sample setting').with({
+          'ensure'  => 'absent',
+          'path'    => '/tmp/foo.ini',
+          'section' => 'foo',
+          'setting' => 'foosetting',
+          'value'   => 'FOO!',
+        })
+      }
+
+      it {
+        should contain_ini_subsetting('colorize_git').with({
+          'ensure'  => 'present',
+          'path'    => '/root/.gitconfig',
+          'section' => 'color',
+          'setting' => 'ui',
+          'value'   => 'auto',
+        })
+      }
+    end
+  end
+end


### PR DESCRIPTION
This added functionality allows you to specify hashes for ini_setting
and ini_subsetting so that they might be stored in Hiera. Without this
patch, you need to use ini_setting and ini_subsetting resources strictly
in code whereas with this patch, you could describe this in Hiera.