### PR TITLE
Modules 1876 - Setting names containing spaces fail

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -10,9 +10,8 @@ module Util
       k_v_s = key_val_separator.strip
 
       @@SECTION_REGEX = /^\s*\[([^\]]*)\]\s*$/
-      @@SETTING_REGEX = /^(\s*)([^\s#{k_v_s}]*)(\s*#{k_v_s}\s*)(.*)\s*$/
-      @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)([^\s#{k_v_s}]*)(\s*#{k_v_s}[ \t]*)(.*)\s*$/
-
+      @@SETTING_REGEX = /^(\s*)([^#;\s]|[^#;\s].*?[^\s#{k_v_s}])(\s*#{k_v_s}\s*)(.*)\s*$/
+      @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)(.*?[^\s#{k_v_s}])(\s*#{k_v_s}[ \t]*)(.*)\s*$/
 
       @path = path
       @key_val_separator = key_val_separator

--- a/spec/acceptance/ini_setting_spec.rb
+++ b/spec/acceptance/ini_setting_spec.rb
@@ -147,9 +147,10 @@ describe 'ini_setting resource' do
 
   describe 'section, setting, value parameters' do
     {
-        "section => 'test', setting => 'foo', value => 'bar',"   => /\[test\]\nfoo = bar/,
-        "section => 'more', setting => 'baz', value => 'quux',"  => /\[more\]\nbaz = quux/,
-        "section => '',     setting => 'top', value => 'level'," => /top = level/,
+        "section => 'test', setting => 'foo', value => 'bar',"         => /\[test\]\nfoo = bar/,
+        "section => 'more', setting => 'baz', value => 'quux',"        => /\[more\]\nbaz = quux/,
+        "section => '',     setting => 'top', value => 'level',"       => /top = level/,
+        "section => 'z',    setting => 'sp aces', value => 'foo bar'," => /\[z\]\nsp aces = foo bar/,
     }.each do |parameter_list, content|
       context parameter_list do
         pp = <<-EOS

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -262,4 +262,25 @@ EOS
       subject.get_value("Drive names", "C:").should eq 'Winchester'
     end
   end
+context 'Configuration with spaces in setting names' do
+    let(:sample_content) do
+      template = <<-EOS
+      [global]
+        # log files split per-machine:
+        log file = /var/log/samba/log.%m
+
+        kerberos method = system keytab
+        passdb backend = tdbsam
+        security = ads
+EOS
+      template.split("\n")
+    end
+
+    it "should expose settings for sections" do
+      subject.get_value("global", "log file").should eq '/var/log/samba/log.%m'
+      subject.get_value("global", "kerberos method").should eq 'system keytab'
+      subject.get_value("global", "passdb backend").should eq 'tdbsam'
+      subject.get_value("global", "security").should eq 'ads'
+    end
+  end
 end

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -262,7 +262,8 @@ EOS
       subject.get_value("Drive names", "C:").should eq 'Winchester'
     end
   end
-context 'Configuration with spaces in setting names' do
+
+  context 'Configuration with spaces in setting names' do
     let(:sample_content) do
       template = <<-EOS
       [global]


### PR DESCRIPTION
>When settings have a names containing spaces, the module fails to detect the existing setting and causes the creation of a duplicate setting.

```
e.g.
ini_setting { "passdb backend":
  ensure  => present,
  path    => '/etc/samba/smb.conf',
  section => 'global',
  setting => 'passdb backend',
  value   => 'tdbsam',
}

Results In:
[global]
passdb backend = tdbsam
passdb backend = tdbsam
passdb backend = tdbsam
```
Closes #155 