### PR TITLE
Adding the ability to change regex match for $section in inifile

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,6 +65,24 @@ ini_subsetting {'sample subsetting':
 }
 ~~~
 
+###Use a non-standard section header
+
+~~~
+default:
+   minage = 1
+   maxage = 13
+
+ini_setting { 'default minage':
+  ensure         => present,
+  path           => '/etc/security/users',
+  section        => 'default',
+  setting        => 'minage',
+  value          => '1',
+  section_prefix => '',
+  section_suffix => ':',
+}
+~~~
+
 ###Implement child providers
 
 
@@ -175,6 +193,16 @@ Determines whether the specified setting should exist. Valid options: 'present' 
 ##### `value`
 
 *Optional.* Supplies a value for the specified setting. Valid options: a string. Default value: undefined.
+
+##### `section_prefix`
+
+*Optional.*  Designates the string that will appear before the section's name.  Default value: "["
+
+##### `section_suffix`
+
+*Optional.*  Designates the string that will appear after the section's name.  Default value: "]"
+
+**NOTE:** The way this type finds all sections in the file is by looking for lines like `${section_prefix}${title}${section_suffix}`
 
 ### Type: ini_subsetting
 

--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -94,9 +94,25 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
     end
   end
 
+  def section_prefix
+    if resource.class.validattr?(:section_prefix)
+      resource[:section_prefix] || '['
+    else
+      '['
+    end
+  end
+
+  def section_suffix
+    if resource.class.validattr?(:section_suffix)
+      resource[:section_suffix] || ']'
+    else
+      ']'
+    end
+  end
+
   private
   def ini_file
-    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator)
+    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix)
   end
 
 end

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -39,5 +39,16 @@ Puppet::Type.newtype(:ini_setting) do
     desc 'The value of the setting to be defined.'
   end
 
+  newparam(:section_prefix) do
+    desc 'The prefix to the section name\'s header.' +
+        'Defaults to \'[\'.'
+    defaultto('[')
+  end
+
+  newparam(:section_suffix) do
+    desc 'The suffix to the section name\'s header.' +
+        'Defaults to \']\'.'
+    defaultto(']')
+  end
 
 end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -137,6 +137,9 @@ url = http://192.168.1.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+-nonstandard-
+  shoes = purple
       EOS
     }
 
@@ -164,6 +167,42 @@ yahoo = yippee
 subby=bar
     #another comment
  ; yet another comment
+
+-nonstandard-
+  shoes = purple
+      EOS
+)
+    end
+
+    it "should add a missing setting to the correct section with pre/suffix" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => 'nonstandard',
+          :setting => 'yahoo', :value => 'yippee',
+          :section_prefix => '-', :section_suffix => '-'))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.create
+      validate_file(<<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+  yahoo = yippee
       EOS
 )
     end
@@ -191,6 +230,9 @@ url = http://192.168.1.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+-nonstandard-
+  shoes = purple
 yahoo = yippee
       EOS
 )
@@ -219,6 +261,41 @@ url = http://192.168.1.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+-nonstandard-
+  shoes = purple
+      EOS
+      )
+    end
+
+    it "should modify an existing setting with pre/suffix with a different value" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+           :section => 'nonstandard',
+           :setting => 'shoes', :value => 'orange',
+           :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be true
+      provider.value=('orange')
+      validate_file(<<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = orange
       EOS
       )
     end
@@ -247,6 +324,9 @@ url = http://192.168.1.1:8080
 subby=foo
     #another comment
  ; yet another comment
+
+-nonstandard-
+  shoes = purple
       EOS
       )
     end
@@ -276,6 +356,43 @@ url = http://192.168.0.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+-nonstandard-
+  shoes = purple
+    EOS
+      )
+    end
+
+    it "should be able to handle settings with pre/suffix with non alphanumbering settings " do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+           :section => 'nonstandard',
+           :setting => 'shoes', :value => 'http://192.168.0.1:8080',
+           :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be true
+      provider.value.should == 'purple'
+      provider.value=('http://192.168.0.1:8080')
+
+      validate_file( <<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = http://192.168.0.1:8080
     EOS
       )
     end
@@ -283,6 +400,15 @@ subby=bar
     it "should recognize an existing setting with the specified value" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :setting => 'baz', :value => 'bazvalue'))
+      provider = described_class.new(resource)
+      provider.exists?.should be true
+    end
+
+    it "should recognize an existing setting with pre/suffix with the specified value" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+           :section => 'nonstandard',
+           :setting => 'shoes', :value => 'purple',
+           :section_prefix => '-', :section_suffix => '-' ))
       provider = described_class.new(resource)
       provider.exists?.should be true
     end
@@ -311,7 +437,44 @@ subby=bar
     #another comment
  ; yet another comment
 
+-nonstandard-
+  shoes = purple
+
 [section3]
+huzzah = shazaam
+      EOS
+      )
+    end
+
+    it "should add a new section with pre/suffix if the section does not exist" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => "section3", :setting => 'huzzah', :value => 'shazaam',
+          :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.create
+      validate_file(<<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+
+-section3-
 huzzah = shazaam
       EOS
       )
@@ -341,7 +504,44 @@ subby=bar
     #another comment
  ; yet another comment
 
+-nonstandard-
+  shoes = purple
+
 [section:subsection]
+huzzah = shazaam
+      EOS
+      )
+    end
+
+    it "should add a new section with pre/suffix if the section does not exist - with colon" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => "section:subsection", :setting => 'huzzah', :value => 'shazaam',
+          :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.create
+      validate_file(<<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+
+-section:subsection-
 huzzah = shazaam
       EOS
       )
@@ -359,6 +559,19 @@ setting1 = hellowworld
 ", emptyfile)
     end
 
+    it "should add a new section with pre/suffix if no sections exists" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => "section1", :setting => 'setting1', :value => 'hellowworld', :path => emptyfile,
+          :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.create
+      validate_file("
+-section1-
+setting1 = hellowworld
+", emptyfile)
+    end
+
     it "should add a new section with colon if no sections exists" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section:subsection", :setting => 'setting1', :value => 'hellowworld', :path => emptyfile))
@@ -371,6 +584,18 @@ setting1 = hellowworld
 ", emptyfile)
     end
 
+    it "should add a new section with pre/suffix with colon if no sections exists" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => "section:subsection", :setting => 'setting1', :value => 'hellowworld', :path => emptyfile,
+          :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.create
+      validate_file("
+-section:subsection-
+setting1 = hellowworld
+", emptyfile)
+    end
     it "should be able to handle variables of any type" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => "section1", :setting => 'master', :value => true))
@@ -576,6 +801,9 @@ url = http://192.168.1.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+ -nonstandard-
+   shoes = purple
 EOS
     }
 
@@ -600,6 +828,38 @@ url = http://192.168.1.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+ -nonstandard-
+   shoes = purple
+EOS
+    )
+    end
+
+    it "should remove a setting with pre/suffix that exists" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+      :section => 'nonstandard', :setting => 'shoes', :ensure => 'absent',
+      :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be true
+      provider.destroy
+      validate_file(<<-EOS
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+ -nonstandard-
 EOS
     )
     end
@@ -626,11 +886,43 @@ url = http://192.168.1.1:8080
 subby=bar
     #another comment
  ; yet another comment
+
+ -nonstandard-
+   shoes = purple
+      EOS
+      )
+    end
+
+    it "should do nothing for a setting with pre/suffix that does not exist" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+         :section => 'nonstandard', :setting => 'foo', :ensure => 'absent',
+         :section_prefix => '-', :section_suffix => '-' ))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.destroy
+      validate_file(<<-EOS
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+ -nonstandard-
+   shoes = purple
       EOS
       )
     end
   end
-
 
   context "when dealing with indentation in sections" do
     let(:orig_content) {


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-1940

We have a customer that needs to manage a file on AIX. They tell us that AIX's configuration files commonly follow the format:

```
key:
    param1 = value1
    param2 = value2
```

This file is basically an inifile, but instead of a section header of

```
[key]
```

...it is

```
key:
```

The regex used to match section names is hard-coded. It would be great to specify the pattern to match section names.