### PR TITLE
(maint) Restore README description for `setting`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -188,7 +188,7 @@ Determines whether the specified setting should exist. Valid options: 'present' 
 
 ##### `setting`
 
-*Optional.* Designates a section of the specified INI file containing the setting to manage. To manage a global setting (at the beginning of the file, before any named sections) enter "". Defaults to "". Valid options: a string.
+*Required.* Designates a setting to manage within the specified INI file and section. Valid options: a string.
 
 ##### `value`
 


### PR DESCRIPTION
Commit ref af78845 erroneously overwrote the README description for the
`setting` parameter with the description for the `section` parameter.
This restores the original description.