### PR TITLE
MODULES-1599 Match only on space and tab whitespace after k/v separator

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -13,7 +13,7 @@ module Util
       @section_suffix = section_suffix
 
       @@SECTION_REGEX = section_regex
-      @@SETTING_REGEX = /^(\s*)([^#;\s]|[^#;\s].*?[^\s#{k_v_s}])(\s*#{k_v_s}\s*)(.*)\s*$/
+      @@SETTING_REGEX = /^(\s*)([^#;\s]|[^#;\s].*?[^\s#{k_v_s}])(\s*#{k_v_s}[ \t]*)(.*)\s*$/
       @@COMMENTED_SETTING_REGEX = /^(\s*)[#;]+(\s*)(.*?[^\s#{k_v_s}])(\s*#{k_v_s}[ \t]*)(.*)\s*$/
 
       @path = path


### PR DESCRIPTION
The previous match for \s would also match on newlines.  This caused
existing settings with blank values to have the newline considered part
of the whitespace surrounding the separator.  When such settings are
set with a value, the value ends up on the next line.

Note that this update to @@SETTING_REGEX for matching only space
and tab, makes it consistent with @@COMMENTED_SETTING_REGEX
which already matches only on those two.

Also adding acceptance test for this particular situation.