### PR TITLE
Add support for Solaris 12

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -250,7 +250,7 @@ Specifies whether the subsetting should be present. Valid options: 'present' and
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Windows 7 and Mac OS X 10.9.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Windows 7, Mac OS X 10.9, and Solaris 12.
 
 ##Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,8 @@
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
Fairly self-explanatory. This simply adds Solaris 12 to metadata.json.
