### PR TITLE
[WIP]Allow to specify an ensure_absent_val

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -35,6 +35,11 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(" = ")
   end
 
+  newparam(:ensure_absent_val) do
+    desc 'A value that is specified as the value property will behave as if ensure => absent was specified'
+    defaultto('nil')
+  end
+
   newproperty(:value) do
     desc 'The value of the setting to be defined.'
   end

--- a/lib/puppet/type/ini_subsetting.rb
+++ b/lib/puppet/type/ini_subsetting.rb
@@ -44,6 +44,11 @@ Puppet::Type.newtype(:ini_subsetting) do
     defaultto(" = ")
   end
 
+  newparam(:ensure_absent_val) do
+    desc 'A value that is specified as the value property will behave as if ensure => absent was specified'
+    defaultto('nil')
+  end
+
   newparam(:quote_char) do
     desc 'The character used to quote the entire value of the setting. ' +
         %q{Valid values are '', '"' and "'". Defaults to ''.}

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -5,7 +5,7 @@ module Puppet
 module Util
   class IniFile
 
-    def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']')
+    def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']', ensure_absent_val = 'nil')
 
       k_v_s = key_val_separator.strip
 
@@ -18,6 +18,7 @@ module Util
 
       @path = path
       @key_val_separator = key_val_separator
+      @ensure_absent_val = ensure_absent_val
       @section_names = []
       @sections_hash = {}
       if File.file?(@path)
@@ -64,38 +65,42 @@ module Util
     end
 
     def set_value(section_name, setting, value)
-      unless (@sections_hash.has_key?(section_name))
-        add_section(Section.new(section_name, nil, nil, nil, nil))
-      end
-
-      section = @sections_hash[section_name]
-
-      if (section.has_existing_setting?(setting))
-        update_line(section, setting, value)
-        section.update_existing_setting(setting, value)
-      elsif result = find_commented_setting(section, setting)
-        # So, this stanza is a bit of a hack.  What we're trying
-        # to do here is this: for settings that don't already
-        # exist, we want to take a quick peek to see if there
-        # is a commented-out version of them in the section.
-        # If so, we'd prefer to add the setting directly after
-        # the commented line, rather than at the end of the section.
-
-        # If we get here then we found a commented line, so we
-        # call "insert_inline_setting_line" to update the lines array
-        insert_inline_setting_line(result, section, setting, value)
-
-        # Then, we need to tell the setting object that we hacked
-        # in an inline setting
-        section.insert_inline_setting(setting, value)
-
-        # Finally, we need to update all of the start/end line
-        # numbers for all of the sections *after* the one that
-        # was modified.
-        section_index = @section_names.index(section_name)
-        increment_section_line_numbers(section_index + 1)
+      if value.eql? @ensure_absent_val
+        self.remove_setting(section_name, setting)
       else
-        section.set_additional_setting(setting, value)
+        unless (@sections_hash.has_key?(section_name))
+          add_section(Section.new(section_name, nil, nil, nil, nil))
+        end
+
+        section = @sections_hash[section_name]
+
+        if (section.has_existing_setting?(setting))
+          update_line(section, setting, value)
+          section.update_existing_setting(setting, value)
+        elsif result = find_commented_setting(section, setting)
+          # So, this stanza is a bit of a hack.  What we're trying
+          # to do here is this: for settings that don't already
+          # exist, we want to take a quick peek to see if there
+          # is a commented-out version of them in the section.
+          # If so, we'd prefer to add the setting directly after
+          # the commented line, rather than at the end of the section.
+
+          # If we get here then we found a commented line, so we
+          # call "insert_inline_setting_line" to update the lines array
+          insert_inline_setting_line(result, section, setting, value)
+
+          # Then, we need to tell the setting object that we hacked
+          # in an inline setting
+          section.insert_inline_setting(setting, value)
+
+          # Finally, we need to update all of the start/end line
+          # numbers for all of the sections *after* the one that
+          # was modified.
+          section_index = @section_names.index(section_name)
+          increment_section_line_numbers(section_index + 1)
+        else
+          section.set_additional_setting(setting, value)
+        end
       end
     end
 


### PR DESCRIPTION
This commit aims to add a new feature for the ini_setting provider, this
feature aims to simulate the ensure => absent behavior when a specific
keyword is specified.

Currently a pattern we have is

```puppet
if $myvar {
  ini_setting { 'SECTION/setting' : value => $myvar }
} else {
  ini_setting { 'SECTION/setting' : ensure => absent }
}
```

If one has dozens or hundreds of parameters to handle then it can easily
make the manifest hard to read.

The solution offer here would turn the above example in something like

```puppet
Ini_setting {
  ensure_absent_val = 'nil' # It is the default
}

ini_setting { 'SECTION/setting' : value => $myvar }
```

If `$myvar` is 'nil' then it will act as if `ensure => absent` would
have been specified. 'nil' being a valid value in some case, this is why
it has been parametrized.

This patch was necessary because none of `value => undef` or `value =>
nil` had the expected behavior.