### PR TITLE
MODULES-2212 - Add use_exact_match parameter for subsettings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -226,7 +226,7 @@ Specifies whether the subsetting should be present. Valid options: 'present' and
 
 ##### `key_val_separator`
 
-*Optional.* Specifies a string to use between subsetting name and value (e.g., to determine whether the separator includes whitespace). Valid options: a string. Default value: ' = '.
+*Optional.* Specifies a string to use between setting name and value (e.g., to determine whether the separator includes whitespace). Valid options: a string. Default value: ' = '.
 
 ##### `path`
 
@@ -252,6 +252,10 @@ Specifies whether the subsetting should be present. Valid options: 'present' and
 ##### `subsetting_separator`
 
 *Optional.* Specifies a string to use between subsettings. Valid options: a string. Default value: " ".
+
+##### `use_exact_match`
+
+*Optional.* Whether to use partial or exact matching for subsetting. Should be set to true if the subsettings do not have values. Valid options: true, false. Default value: false.
 
 ##### `value`
 

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -4,11 +4,11 @@ require File.expand_path('../../../util/setting_value', __FILE__)
 Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def exists?
-    setting_value.get_subsetting_value(subsetting)
+    setting_value.get_subsetting_value(subsetting, resource[:use_exact_match])
   end
 
   def create
-    setting_value.add_subsetting(subsetting, resource[:value])
+    setting_value.add_subsetting(subsetting, resource[:value], resource[:use_exact_match])
     ini_file.set_value(section, setting, setting_value.get_value)
     ini_file.save
     @ini_file = nil
@@ -16,7 +16,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   end
 
   def destroy
-    setting_value.remove_subsetting(subsetting)
+    setting_value.remove_subsetting(subsetting, resource[:use_exact_match])
     ini_file.set_value(section, setting, setting_value.get_value)
     ini_file.save
     @ini_file = nil
@@ -28,7 +28,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   end
 
   def value=(value)
-    setting_value.add_subsetting(subsetting, resource[:value])
+    setting_value.add_subsetting(subsetting, resource[:value], resource[:use_exact_match])
     ini_file.set_value(section, setting, setting_value.get_value)
     ini_file.save
   end

--- a/lib/puppet/type/ini_subsetting.rb
+++ b/lib/puppet/type/ini_subsetting.rb
@@ -56,6 +56,12 @@ Puppet::Type.newtype(:ini_subsetting) do
     end
   end
 
+  newparam(:use_exact_match) do
+    desc 'Set to true if your subsettings don\'t have values and you want to use exact matches to determine if the subsetting exists. See MODULES-2212'
+    newvalues(:true, :false)
+    defaultto(:false)
+  end
+
   newproperty(:value) do
     desc 'The value of the subsetting to be defined.'
   end

--- a/lib/puppet/util/setting_value.rb
+++ b/lib/puppet/util/setting_value.rb
@@ -51,27 +51,32 @@ module Puppet
         @quote_char + result + @quote_char
       end
 
-      def get_subsetting_value(subsetting)
+      def get_subsetting_value(subsetting, use_exact_match=:false)
 
         value = nil
 
         @subsetting_items.each { |item|
-          if(item.start_with?(subsetting))
+          if(use_exact_match == :false and item.start_with?(subsetting))
             value = item[subsetting.length, item.length - subsetting.length]
             break
+          elsif(use_exact_match == :true and item.eql?(subsetting))
+            return true
           end
         }
 
         value
       end
 
-      def add_subsetting(subsetting, subsetting_value)
+      def add_subsetting(subsetting, subsetting_value, use_exact_match=:false)
 
         new_item = subsetting + (subsetting_value || '')
         found = false
 
         @subsetting_items.map! { |item|
-          if item.start_with?(subsetting)
+          if use_exact_match == :false and item.start_with?(subsetting)
+            value = new_item
+            found = true
+          elsif use_exact_match == :true and item.eql?(subsetting)
             value = new_item
             found = true
           else
@@ -86,8 +91,12 @@ module Puppet
         end
       end
 
-      def remove_subsetting(subsetting)
-        @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting) ? nil : item }.compact
+      def remove_subsetting(subsetting, use_exact_match=:false)
+        if use_exact_match == :false
+          @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting) ? nil : item }.compact
+        else
+          @subsetting_items = @subsetting_items.map { |item| item.eql?(subsetting) ? nil : item }.compact
+        end
       end
     end
   end

--- a/lib/puppet/util/setting_value.rb
+++ b/lib/puppet/util/setting_value.rb
@@ -1,95 +1,94 @@
 module Puppet
-module Util
+  module Util
 
-  class SettingValue
+    class SettingValue
 
-    def initialize(setting_value, subsetting_separator = ' ', default_quote_char = nil)
-      @setting_value = setting_value
-      @subsetting_separator = subsetting_separator
+      def initialize(setting_value, subsetting_separator = ' ', default_quote_char = nil)
+        @setting_value = setting_value
+        @subsetting_separator = subsetting_separator
 
-      default_quote_char ||= ''
+        default_quote_char ||= ''
 
-      if @setting_value
-        unquoted, @quote_char = unquote_setting_value(setting_value)
-        @subsetting_items = unquoted.scan(Regexp.new("(?:(?:[^\\#{@subsetting_separator}]|\\.)+)"))  # an item can contain escaped separator
-        @subsetting_items.map! { |item| item.strip }
-        @quote_char = default_quote_char if @quote_char.empty?
-      else
-        @subsetting_items = []
-        @quote_char = default_quote_char
-      end     
-    end
-
-    def unquote_setting_value(setting_value)
-      quote_char = ""
-      if (setting_value.start_with?('"') and setting_value.end_with?('"'))
-        quote_char = '"'
-      elsif (setting_value.start_with?("'") and setting_value.end_with?("'"))
-        quote_char = "'"
-      end
-
-      unquoted = setting_value
-
-      if (quote_char != "")
-        unquoted = setting_value[1, setting_value.length - 2]
-      end
-
-      [unquoted, quote_char]
-    end
-
-    def get_value
-    
-      result = ""
-      first = true
-      
-      @subsetting_items.each { |item|
-        result << @subsetting_separator unless first
-        result << item        
-        first = false
-      }
-      
-      @quote_char + result + @quote_char
-    end
-
-    def get_subsetting_value(subsetting)
-    
-      value = nil
-      
-      @subsetting_items.each { |item|
-        if(item.start_with?(subsetting))
-          value = item[subsetting.length, item.length - subsetting.length]
-          break
-        end
-      }
-      
-      value
-    end
-    
-    def add_subsetting(subsetting, subsetting_value)
-    
-      new_item = subsetting + (subsetting_value || '')
-      found = false
-
-      @subsetting_items.map! { |item|
-        if item.start_with?(subsetting)
-          value = new_item
-          found = true
+        if @setting_value
+          unquoted, @quote_char = unquote_setting_value(setting_value)
+          @subsetting_items = unquoted.scan(Regexp.new("(?:(?:[^\\#{@subsetting_separator}]|\\.)+)"))  # an item can contain escaped separator
+          @subsetting_items.map! { |item| item.strip }
+          @quote_char = default_quote_char if @quote_char.empty?
         else
-          value = item
+          @subsetting_items = []
+          @quote_char = default_quote_char
         end
-        
+      end
+
+      def unquote_setting_value(setting_value)
+        quote_char = ""
+        if (setting_value.start_with?('"') and setting_value.end_with?('"'))
+          quote_char = '"'
+        elsif (setting_value.start_with?("'") and setting_value.end_with?("'"))
+          quote_char = "'"
+        end
+
+        unquoted = setting_value
+
+        if (quote_char != "")
+          unquoted = setting_value[1, setting_value.length - 2]
+        end
+
+        [unquoted, quote_char]
+      end
+
+      def get_value
+
+        result = ""
+        first = true
+
+        @subsetting_items.each { |item|
+          result << @subsetting_separator unless first
+          result << item
+          first = false
+        }
+
+        @quote_char + result + @quote_char
+      end
+
+      def get_subsetting_value(subsetting)
+
+        value = nil
+
+        @subsetting_items.each { |item|
+          if(item.start_with?(subsetting))
+            value = item[subsetting.length, item.length - subsetting.length]
+            break
+          end
+        }
+
         value
-      }
-      
-      unless found
-        @subsetting_items.push(new_item)
+      end
+
+      def add_subsetting(subsetting, subsetting_value)
+
+        new_item = subsetting + (subsetting_value || '')
+        found = false
+
+        @subsetting_items.map! { |item|
+          if item.start_with?(subsetting)
+            value = new_item
+            found = true
+          else
+            value = item
+          end
+
+          value
+        }
+
+        unless found
+          @subsetting_items.push(new_item)
+        end
+      end
+
+      def remove_subsetting(subsetting)
+        @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting) ? nil : item }.compact
       end
     end
-
-    def remove_subsetting(subsetting)   
-      @subsetting_items = @subsetting_items.map { |item| item.start_with?(subsetting) ? nil : item }.compact
-    end
-    
   end
-end
 end

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -132,4 +132,50 @@ somenewsetting = puppetdb
     end
 
   end
+
+  context "when working with subsettings in files with use_exact_match" do
+    let(:common_params) { {
+        :title           => 'ini_setting_ensure_present_test',
+        :path            => tmpfile,
+        :section         => 'master',
+        :setting         => 'reports',
+        :use_exact_match => true,
+    } }
+
+    let(:orig_content) {
+      <<-EOS
+[master]
+
+reports = http,foo
+      EOS
+    }
+
+    it "should add a new subsetting when the 'parent' setting already exists" do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(
+          :subsetting => 'fo', :subsetting_separator => ','))
+      provider = described_class.new(resource)
+      provider.value=('')
+      validate_file(<<-eos
+[master]
+
+reports = http,foo,fo
+      eos
+      )
+    end
+
+    it "should not remove substring subsettings" do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(
+          :subsetting => 'fo', :subsetting_separator => ','))
+      provider = described_class.new(resource)
+      provider.value=('')
+      provider.destroy
+      validate_file(<<-EOS
+[master]
+
+reports = http,foo
+      EOS
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
There's no way to distinguish between a subsetting with a value and a subsetting with no value, so add a parameter to allow that to be specified.