### PR TITLE
[MODULES-2369] Support a space as a key_val_separator

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -7,7 +7,7 @@ module Util
 
     def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']')
 
-      k_v_s = key_val_separator.strip
+      k_v_s = key_val_separator =~ /^\s+$/ ? ' ' : key_val_separator.strip
 
       @section_prefix = section_prefix
       @section_suffix = section_suffix

--- a/spec/acceptance/ini_setting_spec.rb
+++ b/spec/acceptance/ini_setting_spec.rb
@@ -262,6 +262,8 @@ describe 'ini_setting resource' do
         ""                             => /two = three/,
         "key_val_separator => '=',"    => /two=three/,
         "key_val_separator => ' =  '," => /two =  three/,
+        "key_val_separator => ' '," => /two three/,
+        "key_val_separator => '   '," => /two   three/,
     }.each do |parameter, content|
       context "with \"#{parameter}\" makes \"#{content}\"" do
         pp = <<-EOS

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -783,6 +783,49 @@ bar: baz
 
   end
 
+  context "when overriding the separator to a space" do
+    let(:orig_content) {
+      <<-EOS
+[section2]
+foo bar
+      EOS
+    }
+
+    it "should modify an existing setting" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+                                                   :section           => 'section2',
+                                                   :setting           => 'foo',
+                                                   :value             => 'yippee',
+                                                   :key_val_separator => ' '))
+      provider = described_class.new(resource)
+      provider.exists?.should be true
+      provider.value.should == 'bar'
+      provider.value=('yippee')
+      validate_file(<<-EOS
+[section2]
+foo yippee
+      EOS
+      )
+    end
+
+    it "should add a new setting" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+                                                   :section           => 'section2',
+                                                   :setting           => 'bar',
+                                                   :value             => 'baz',
+                                                   :key_val_separator => ' '))
+      provider = described_class.new(resource)
+      provider.exists?.should be false
+      provider.create
+      validate_file(<<-EOS
+[section2]
+foo bar
+bar baz
+      EOS
+      )
+    end
+  end
+
   context "when ensuring that a setting is absent" do
     let(:orig_content) {
       <<-EOS


### PR DESCRIPTION
Previously, trying to use a space as a key_val_separator in the ini_setting
type would fail because #strip is being called on the key_val_separator
attribute, which completely kills the space. This commit checks to see
if key_val_separator has been set as a space, and, if so, sets the `k_v_s`
variable in the library to be ' ' instead of ''.  This in turn allows the
provider to check for existing values (instead of inserting the value every
time Puppet is run).