### PR TITLE
Adding path to create_ini_settings resources

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -284,7 +284,7 @@ create_ini_settings($example, $defaults)
 ~~~
 results in a resource
 ~~~
-ini_setting { '[section1] setting1':
+ini_setting { '/tmp/foo.ini [section1] setting1':
     ensure  => present,
     section => 'section1',
     setting => 'setting1',
@@ -307,14 +307,14 @@ create_ini_settings($example, $defaults)
 ~~~
 results in resources
 ~~~
-ini_setting { '[section1] setting1':
+ini_setting { '/tmp/foo.ini [section1] setting1':
     ensure  => present,
     section => 'section1',
     setting => 'setting1',
     value   => 'value1',
     path    => '/tmp/foo.ini',
 }
-ini_setting { '[section1] setting2':
+ini_setting { '/tmp/foo.ini [section1] setting2':
     ensure  => absent,
     section => 'section1',
     setting => 'setting2',
@@ -324,12 +324,12 @@ ini_setting { '[section1] setting2':
 
 ##### `$defaults`
 
-*Optional, but recommended.* 
+*Optional, but recommended.*
 
 This works exactly like `create_resources` defaults parameter. Use it to not repeat yourself to often
 and write settings more densely. Example usage see parameter `$settings` above.
 
-If you omit this parameter, you will need to add the `path` and `value` attribute to every single setting as a hash 
+If you omit this parameter, you will need to add the `path` and `value` attribute to every single setting as a hash
 (`$example = { 'section1' => { 'setting1' => { 'value' => 'value1', 'path' => '/tmp/foo.ini' } } }`).
 This most certainly is not what you want, but if you need it it's there.
 

--- a/lib/puppet/parser/functions/create_ini_settings.rb
+++ b/lib/puppet/parser/functions/create_ini_settings.rb
@@ -24,21 +24,21 @@ Uses create_resources to create a set of ini_setting resources from a hash:
 
 Will create the following resources
 
-    ini_setting{'[section1] setting1':
+    ini_setting{'/tmp/foo.ini [section1] setting1':
       ensure  => present,
       section => 'section1',
       setting => 'setting1',
       value   => 'val1',
       path    => '/tmp/foo.ini',
     }
-    ini_setting{'[section2] setting2':
+    ini_setting{'/tmp/foo.ini [section2] setting2':
       ensure  => present,
       section => 'section2',
       setting => 'setting2',
       value   => 'val2',
       path    => '/tmp/foo.ini',
     }
-    ini_setting{'[section2] setting3':
+    ini_setting{'/tmp/foo.ini [section2] setting3':
       ensure  => absent,
       section => 'section2',
       setting => 'setting3',
@@ -64,8 +64,12 @@ EOS
         "create_ini_settings(): Section #{section} must contain a Hash") \
         unless settings[section].is_a?(Hash)
 
+      unless path = defaults.merge(settings)['path']
+        raise Puppet::ParseError, 'create_ini_settings(): must pass the path parameter to the Ini_setting resource!'
+      end
+
       settings[section].each do |setting, value|
-        res["[#{section}] #{setting}"] = {
+        res["#{path} [#{section}] #{setting}"] = {
           'ensure'  => 'present',
           'section' => section,
           'setting' => setting,

--- a/spec/classes/create_ini_settings_test_spec.rb
+++ b/spec/classes/create_ini_settings_test_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 # end-to-end test of the create_init_settings function
 describe 'create_ini_settings_test' do
   it { should have_ini_setting_resource_count(3) }
-  it { should contain_ini_setting('[section1] setting1').with(
+  it { should contain_ini_setting('/tmp/foo.ini [section1] setting1').with(
     :ensure  => 'present',
     :section => 'section1',
     :setting => 'setting1',
     :value   => 'val1',
     :path    => '/tmp/foo.ini'
   )}
-  it { should contain_ini_setting('[section2] setting2').with(
+  it { should contain_ini_setting('/tmp/foo.ini [section2] setting2').with(
     :ensure  => 'present',
     :section => 'section2',
     :setting => 'setting2',
     :value   => 'val2',
     :path    => '/tmp/foo.ini'
   )}
-  it { should contain_ini_setting('[section2] setting3').with(
+  it { should contain_ini_setting('/tmp/foo.ini [section2] setting3').with(
     :ensure  => 'absent',
     :section => 'section2',
     :setting => 'setting3',

--- a/spec/functions/create_ini_settings_spec.rb
+++ b/spec/functions/create_ini_settings_spec.rb
@@ -10,14 +10,15 @@ describe 'create_ini_settings' do
   end
 
   describe 'argument handling' do
-    it { should run.with_params.and_raise_error(Puppet::ParseError, /0 for 1 or 2/) }
-    it { should run.with_params(1,2,3).and_raise_error(Puppet::ParseError, /3 for 1 or 2/) }
-    it { should run.with_params('foo').and_raise_error(Puppet::ParseError, /Requires all arguments/) }
-    it { should run.with_params({},'foo').and_raise_error(Puppet::ParseError, /Requires all arguments/) }
+    it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, /0 for 1 or 2/) }
+    it { is_expected.to run.with_params(1,2,3).and_raise_error(Puppet::ParseError, /3 for 1 or 2/) }
+    it { is_expected.to run.with_params('foo').and_raise_error(Puppet::ParseError, /Requires all arguments/) }
+    it { is_expected.to run.with_params({},'foo').and_raise_error(Puppet::ParseError, /Requires all arguments/) }
 
-    it { should run.with_params({}) }
-    it { should run.with_params({},{}) }
+    it { is_expected.to run.with_params({}) }
+    it { is_expected.to run.with_params({},{}) }
 
-    it { should run.with_params({ 1 => 2 }).and_raise_error(Puppet::ParseError, /Section 1 must contain a Hash/) }
+    it { is_expected.to run.with_params({ 'section' => { 'setting' => 'value' }}).and_raise_error(Puppet::ParseError, /must pass the path parameter/) }
+    it { is_expected.to run.with_params({ 1 => 2 }).and_raise_error(Puppet::ParseError, /Section 1 must contain a Hash/) }
   end
 end


### PR DESCRIPTION
Currently the `create_ini_settings` function creates an `ini_setting` resource with a title comprised of the `section` and `setting` values. This means that we run into resource conflicts when defining the same section/setting combinations but in different files. Since the `path` parameter is required, we can safely add this to the title of the `ini_setting` resource created by the `create_ini_settings` function. This commit does just that.