### PR TITLE
(maint) Fix README for ini_setting parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -302,11 +302,11 @@ Determines whether the specified setting should exist. Valid options: 'present' 
 
 ##### `section`
 
-*Required.* Designates a section of the specified INI file containing the setting to manage. To manage a global setting (at the beginning of the file, before any named sections) enter "". Valid options: a string.
+*Optional.* Designates a section of the specified INI file containing the setting to manage. To manage a global setting (at the beginning of the file, before any named sections) enter "". Defaults to "". Valid options: a string.
 
 ##### `setting`
 
-*Optional.* The name of the setting to define. Valid options: a string.
+*Required.* Designates a setting to manage within the specified INI file and section. Valid options: a string.
 
 ##### `value`
 


### PR DESCRIPTION
Update descriptions of the `section` parameter and the `setting`
parameter in `ini_setting` to match the descriptions in
`ini_subsetting`. Commit af78845 erroneously updated the README
description for the `setting` parameter with a description intended for
the `section` parameter.