### PR TITLE
Remove brackets from ini_setting titles to workaround PUP-4709

### DIFF
--- a/lib/puppet/parser/functions/create_ini_settings.rb
+++ b/lib/puppet/parser/functions/create_ini_settings.rb
@@ -69,7 +69,7 @@ EOS
       end
 
       settings[section].each do |setting, value|
-        res["#{path} [#{section}] #{setting}"] = {
+        res["#{path} #{section} #{setting}"] = {
           'ensure'  => 'present',
           'section' => section,
           'setting' => setting,

--- a/spec/classes/create_ini_settings_test_spec.rb
+++ b/spec/classes/create_ini_settings_test_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 # end-to-end test of the create_init_settings function
 describe 'create_ini_settings_test' do
   it { should have_ini_setting_resource_count(3) }
-  it { should contain_ini_setting('/tmp/foo.ini [section1] setting1').with(
+  it { should contain_ini_setting('/tmp/foo.ini section1 setting1').with(
     :ensure  => 'present',
     :section => 'section1',
     :setting => 'setting1',
     :value   => 'val1',
     :path    => '/tmp/foo.ini'
   )}
-  it { should contain_ini_setting('/tmp/foo.ini [section2] setting2').with(
+  it { should contain_ini_setting('/tmp/foo.ini section2 setting2').with(
     :ensure  => 'present',
     :section => 'section2',
     :setting => 'setting2',
     :value   => 'val2',
     :path    => '/tmp/foo.ini'
   )}
-  it { should contain_ini_setting('/tmp/foo.ini [section2] setting3').with(
+  it { should contain_ini_setting('/tmp/foo.ini section2 setting3').with(
     :ensure  => 'absent',
     :section => 'section2',
     :setting => 'setting3',


### PR DESCRIPTION
Puppet 4.0 and 4.1 are affected by PUP-4709 which raises duplicate
resource errors when using create_ini_settings(), due to the inclusion
of square brackets in the resource titles.

    Error while evaluating a Function Call, Duplicate
    declaration: Ini_setting[[foo] bar] is already declared; cannot
    redeclare

Removing these from the function allows it to work on these Puppet
versions without error.

Replaces #195.