### PR TITLE
Remove empty sections after last setting is removed

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -134,6 +134,11 @@ module Util
           end
 
           if ! section.is_new_section?
+            # don't add empty sections
+            if section.empty? and ! section.is_global?
+              next
+            end
+
             # write all of the pre-existing settings
             (section.start_line..section.end_line).each do |line_num|
               line = lines[line_num]

--- a/lib/puppet/util/ini_file/section.rb
+++ b/lib/puppet/util/ini_file/section.rb
@@ -1,6 +1,4 @@
-module Puppet
-module Util
-class IniFile
+class Puppet::Util::IniFile
   class Section
     # Some implementation details:
     #
@@ -42,6 +40,10 @@ class IniFile
 
     def has_existing_setting?(setting_name)
       @existing_settings.has_key?(setting_name)
+    end
+
+    def empty?
+      start_line == end_line
     end
 
     def update_existing_setting(setting_name, value)
@@ -98,6 +100,4 @@ class IniFile
     end
 
   end
-end
-end
 end


### PR DESCRIPTION
Empty sections hanging around are not useful, so if the last line in a
section is removed then remove the section. If the section still has
comments, then just leave it be.

This does not add the ability to remove sections that do not have
settings to begin with; only allows cleaning a file as puppet makes
changes to it.