### PR TITLE
(MODULES-3145) Cast values to strings before passing to provider

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -71,6 +71,10 @@ Puppet::Type.newtype(:ini_setting) do
   newproperty(:value) do
     desc 'The value of the setting to be defined.'
 
+    munge do |value|
+      value.to_s
+    end
+
     def should_to_s(newvalue)
       if (@resource[:show_diff] == :true && Puppet[:show_diff]) then
         return newvalue

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -268,6 +268,36 @@ subby=bar
       )
     end
 
+    it "should modify an existing setting with a different boolean value" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+        :section => 'section1', :setting => 'master', :value => false))
+      provider = described_class.new(resource)
+      provider.exists?.should be true
+      expect(Puppet::Transaction::ResourceHarness.new(nil).evaluate(provider.resource).out_of_sync).to eq(true)
+      validate_file(<<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = false
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+      EOS
+)
+    end
+
     it "should modify an existing setting with pre/suffix with a different value" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
            :section => 'nonstandard',


### PR DESCRIPTION
Puppet gets confused when false values get passed to the provider
because of
https://github.com/puppetlabs/puppet/blob/4.4.0/lib/puppet/property.rb#L247-L248
so lets just cast them all to strings; ini files are untyped anyway.