### PR TITLE
Added refreshonly Parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -331,6 +331,33 @@ Global show_diff configuraton takes priority over this one -
 
 *Optional.*  Designates the string that will appear after the section's name.  Default value: "]".
 
+##### `refreshonly`
+
+*Optional.*  A boolean to indicate whether or not the value associated with the setting should be updated if this resource is only part of a refresh event.  Default value: **false**.
+
+For example, if we want a timestamp associated with the last time a setting's value was updated, we could do something like this:
+
+~~~
+ini_setting { 'foosetting':
+  ensure  => present,
+  path    => '/tmp/file.ini',
+  section => 'foo',
+  setting => 'foosetting',
+  value   => 'bar',
+  notify  => Ini_Setting['foosetting_timestamp'],
+}
+
+$now = strftime('%Y-%m-%d %H:%M:%S')
+ini_setting {'foosetting_timestamp':
+  ensure      => present,
+  path        => '/tmp/file.ini',
+  section     => 'foo',
+  setting     => 'foosetting_timestamp',
+  value       => $now,
+  refreshonly => true,
+}
+~~~
+
 **NOTE:** This type finds all sections in the file by looking for lines like `${section_prefix}${title}${section_suffix}`.
 
 ### Type: ini_subsetting

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -88,6 +88,15 @@ Puppet::Type.newtype(:ini_setting) do
     def is_to_s(value)
       should_to_s(value)
     end
+
+    def insync?(current)
+      if (@resource[:refreshonly]) then
+        true
+      else
+        current == should
+      end
+    end
+
   end
 
   newparam(:section_prefix) do
@@ -100,6 +109,20 @@ Puppet::Type.newtype(:ini_setting) do
     desc 'The suffix to the section name\'s header.' +
       'Defaults to \']\'.'
     defaultto(']')
+  end
+
+  newparam(:refreshonly) do
+    desc 'A flag indicating whether or not the ini_setting should be updated '+
+         'only when called as part of a refresh event'
+    defaultto false
+    newvalues(true,false)
+  end
+
+  def refresh
+    if self[:refreshonly] then
+      # update the value in the provider, which will save the value to the ini file
+      provider.value = self[:value]
+    end
   end
 
 end


### PR DESCRIPTION
From original author: Working with a recent customer, they had a product whose ini files have timestamps in them associated with particular settings. When those settings are updated, it is expected that the timestamp be updated as well. To do this with ini_setting, we need it to respond to refresh events and have a way of only updating a value if a refresh event occurs. Hence the little modification to make this possible.

From jonnytpuppet: Changed parameter to be called refreshonly, squashed commits, and removed metadata changes.