### PR TITLE
Use parallel_tests 2.9.0 for ruby < 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet', '>= 2.3.2'
   gem 'rspec-puppet-facts'
   gem 'simplecov'
-  gem 'parallel_tests'
+  gem 'parallel_tests', '2.9.0' if RUBY_VERSION < '2.0.0'
   gem 'rubocop', '0.41.2' if RUBY_VERSION < '2.0.0'
   gem 'rubocop' if RUBY_VERSION >= '2.0.0'
   gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'


### PR DESCRIPTION
Parallel_tests 2.10.0 requires ruby >= 2.0.0, so for jobs with
ruby < 2.0.0 parallel_tests 2.9.0 should be used.