### PR TITLE
(MODULES-4170) Fix path validation on windows

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -43,7 +43,7 @@ Puppet::Type.newtype(:ini_setting) do
   newparam(:path) do
     desc 'The ini file Puppet will ensure contains the specified setting.'
     validate do |value|
-      unless (Puppet.features.posix? and value =~ /^\//) or (Puppet.features.microsoft_windows? and (value =~ /^.:\// or value =~ /^\/\/[^\/]+\/[^\/]+/))
+      unless Puppet::Util.absolute_path?(value)
         raise(Puppet::Error, "File paths must be fully qualified, not '#{value}'")
       end
     end

--- a/spec/unit/puppet/type/ini_setting_spec.rb
+++ b/spec/unit/puppet/type/ini_setting_spec.rb
@@ -4,6 +4,56 @@ require 'spec_helper'
 ini_setting = Puppet::Type.type(:ini_setting)
 
 describe ini_setting do
+  describe 'path validation' do
+    subject { lambda { described_class.new(:name => 'foo', :path => path) } }
+
+    context 'on posix platforms' do
+      before(:each) { Puppet.features.stub(:posix?) { true } }
+      before(:each) { Puppet.features.stub(:microsoft_windows?) { false } }
+      before(:each) { Puppet::Util::Platform.stub(:windows?) { false } }
+
+      context 'with an absolute path' do
+        let(:path) { '/absolute/path' }
+        it { should_not raise_exception }
+      end
+
+      context 'with a relative path' do
+        let(:path) { 'relative/path' }
+        it { should raise_exception }
+      end
+    end
+
+    context 'on windows platforms' do
+      before(:each) { Puppet.features.stub(:posix?) { false } }
+      before(:each) { Puppet.features.stub(:microsoft_windows?) { true } }
+      before(:each) { Puppet::Util::Platform.stub(:windows?) { true } }
+
+      context 'with an absolute path with front slashes' do
+        let(:path) { 'c:/absolute/path' }
+        it { should_not raise_exception }
+      end
+
+      context 'with an absolute path with backslashes' do
+        let(:path) { 'c:\absolute\path' }
+        it { should_not raise_exception }
+      end
+
+      context 'with an absolute path with mixed slashes' do
+        let(:path) { 'c:/absolute\path' }
+        it { should_not raise_exception }
+      end
+
+      context 'with a relative path with front slashes' do
+        let(:path) { 'relative/path' }
+        it { should raise_exception }
+      end
+
+      context 'with a relative path with back slashes' do
+        let(:path) { 'relative\path' }
+        it { should raise_exception }
+      end
+    end
+  end
 
   [true, false].product([true, false, "true", "false", "md5", :md5]).each do |cfg, param|
     describe "when Puppet[:show_diff] is #{cfg} and show_diff => #{param}" do


### PR DESCRIPTION
The path parameter was being validated on windows with a broken regex.
Instead use the absolute_path? function from Puppet::Util, which has a
regex that works.