### PR TITLE
MODULES-3624 Allow setting indent character

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -99,7 +99,8 @@ ini_setting { 'procedure cache size':
   section        => 'SQL Server Administration',
   setting        => 'procedure cache size',
   value          => '15000',
-  indent         => "\t",
+  indent_char    => "\t",
+  indent_width   => 2,
 }
 ~~~
 
@@ -107,7 +108,7 @@ Results in:
 
 ~~~puppet
 [SQL Server Administration]
-	procedure cache size = 15000
+		procedure cache size = 15000
 ~~~
 
 ### Implement child providers

--- a/README.markdown
+++ b/README.markdown
@@ -352,9 +352,13 @@ Global show_diff configuraton takes priority over this one -
 
 *Optional.*  Designates the string that will appear after the section's name.  Default value: "]".
 
-##### `indent`
+##### `indent_char`
 
-*Optional.*  Designates the string that will be used to indent newly created settings. This will not affect settings which already exist in the file, even if they are changed. Default value: " ".
+*Optional.*  Designates the character (or string) that will be used to indent newly created settings. This will not affect settings which already exist in the file, even if they are changed. Default value: " ".
+
+##### `indent_width`
+
+*Optional.*  Designates the number of `indent_char` to indent newly inserted settings by. If this is not defined, the default is to compute the indentation automatically from existing settings in the section, or no indent if the section does not yet exist. This will not affect settings which already exist in the file, even if they are changed.
 
 ##### `refreshonly`
 

--- a/README.markdown
+++ b/README.markdown
@@ -90,6 +90,26 @@ default:
    minage = 1
 ~~~
 
+### Use a non-standard indent character (or string) for added settings
+
+~~~puppet
+ini_setting { 'procedure cache size':
+  ensure         => present,
+  path           => '/var/lib/ase/config/ASE-16_0/SYBASE.cfg',
+  section        => 'SQL Server Administration',
+  setting        => 'procedure cache size',
+  value          => '15000',
+  indent         => "\t",
+}
+~~~
+
+Results in:
+
+~~~puppet
+[SQL Server Administration]
+	procedure cache size = 15000
+~~~
+
 ### Implement child providers
 
 You might want to create child providers that inherit the `ini_setting` provider, for one or both of these purposes:
@@ -330,6 +350,10 @@ Global show_diff configuraton takes priority over this one -
 ##### `section_suffix`
 
 *Optional.*  Designates the string that will appear after the section's name.  Default value: "]".
+
+##### `indent`
+
+*Optional.*  Designates the string that will be used to indent newly created settings. This will not affect settings which already exist in the file, even if they are changed. Default value: " ".
 
 ##### `refreshonly`
 

--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -128,7 +128,7 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
 
   private
   def ini_file
-    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent)
+    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
   end
 
 end

--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -110,11 +110,19 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
     end
   end
 
-  def indent
-    if resource.class.validattr?(:indent)
-      resource[:indent] || ' '
+  def indent_char
+    if resource.class.validattr?(:indent_char)
+      resource[:indent_char] || ' '
     else
       ' '
+    end
+  end
+
+  def indent_width
+    if resource.class.validattr?(:indent_width)
+      resource[:indent_width] || nil
+    else
+      nil
     end
   end
 

--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -110,9 +110,17 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
     end
   end
 
+  def indent
+    if resource.class.validattr?(:indent)
+      resource[:indent] || ' '
+    else
+      ' '
+    end
+  end
+
   private
   def ini_file
-    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix)
+    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent)
   end
 
 end

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -111,10 +111,16 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(']')
   end
 
-  newparam(:indent) do
-    desc 'The character to indent settings with.' +
+  newparam(:indent_char) do
+    desc 'The character to indent new settings with.' +
       'Defaults to \' \'.'
     defaultto(' ')
+  end
+
+  newparam(:indent_width) do
+    desc 'The number of indent_chars to use to indent a new setting.' +
+      'Defaults to undef (autodetect).'
+    defaultto(:undef)
   end
 
   newparam(:refreshonly) do
@@ -130,5 +136,4 @@ Puppet::Type.newtype(:ini_setting) do
       provider.value = self[:value]
     end
   end
-
 end

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -120,7 +120,6 @@ Puppet::Type.newtype(:ini_setting) do
   newparam(:indent_width) do
     desc 'The number of indent_chars to use to indent a new setting.' +
       'Defaults to undef (autodetect).'
-    defaultto(:undef)
   end
 
   newparam(:refreshonly) do

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -111,6 +111,12 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(']')
   end
 
+  newparam(:indent) do
+    desc 'The character to indent settings with.' +
+      'Defaults to \' \'.'
+    defaultto(' ')
+  end
+
   newparam(:refreshonly) do
     desc 'A flag indicating whether or not the ini_setting should be updated '+
          'only when called as part of a refresh event'

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -13,7 +13,7 @@ module Util
       @section_prefix = section_prefix
       @section_suffix = section_suffix
       @indent_char = indent_char
-      @indent_width = indent_width
+      @indent_width = indent_width ? indent_width.to_i : nil
 
       @@SECTION_REGEX = section_regex
       @@SETTING_REGEX = /^(\s*)([^#;\s]|[^#;\s].*?[^\s#{k_v_s}])(\s*#{k_v_s}[ \t]*)(.*)\s*$/

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -5,12 +5,14 @@ module Puppet
 module Util
   class IniFile
 
-    def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']')
+    def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']',
+                   indent = ' ')
 
       k_v_s = key_val_separator =~ /^\s+$/ ? ' ' : key_val_separator.strip
 
       @section_prefix = section_prefix
       @section_suffix = section_suffix
+      @indent = indent
 
       @@SECTION_REGEX = section_regex
       @@SETTING_REGEX = /^(\s*)([^#;\s]|[^#;\s].*?[^\s#{k_v_s}])(\s*#{k_v_s}[ \t]*)(.*)\s*$/
@@ -174,7 +176,7 @@ module Util
 
           # write new settings, if there are any
           section.additional_settings.each_pair do |key, value|
-            fh.puts("#{' ' * (section.indentation || 0)}#{key}#{@key_val_separator}#{value}")
+            fh.puts("#{@indent * (section.indentation || 0)}#{key}#{@key_val_separator}#{value}")
           end
 
           if (whitespace_buffer.length > 0)
@@ -309,7 +311,7 @@ module Util
       line_num = result[:line_num]
       match = result[:match]
       s = complete_setting
-      lines.insert(line_num + 1, "#{' ' * (section.indentation || 0 )}#{s[:setting]}#{s[:separator]}#{s[:value]}")
+      lines.insert(line_num + 1, "#{@indent * (section.indentation || 0 )}#{s[:setting]}#{s[:separator]}#{s[:value]}")
     end
 
     # Utility method; given a section index (index into the @section_names

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -6,13 +6,14 @@ module Util
   class IniFile
 
     def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']',
-                   indent = ' ')
+                   indent_char = ' ', indent_width = nil)
 
       k_v_s = key_val_separator =~ /^\s+$/ ? ' ' : key_val_separator.strip
 
       @section_prefix = section_prefix
       @section_suffix = section_suffix
-      @indent = indent
+      @indent_char = indent_char
+      @indent_width = indent_width
 
       @@SECTION_REGEX = section_regex
       @@SETTING_REGEX = /^(\s*)([^#;\s]|[^#;\s].*?[^\s#{k_v_s}])(\s*#{k_v_s}[ \t]*)(.*)\s*$/
@@ -176,7 +177,7 @@ module Util
 
           # write new settings, if there are any
           section.additional_settings.each_pair do |key, value|
-            fh.puts("#{@indent * (section.indentation || 0)}#{key}#{@key_val_separator}#{value}")
+            fh.puts("#{@indent_char * (@indent_width || section.indentation || 0)}#{key}#{@key_val_separator}#{value}")
           end
 
           if (whitespace_buffer.length > 0)
@@ -311,7 +312,7 @@ module Util
       line_num = result[:line_num]
       match = result[:match]
       s = complete_setting
-      lines.insert(line_num + 1, "#{@indent * (section.indentation || 0 )}#{s[:setting]}#{s[:separator]}#{s[:value]}")
+      lines.insert(line_num + 1, "#{@indent_char * (@indent_width || section.indentation || 0 )}#{s[:setting]}#{s[:separator]}#{s[:value]}")
     end
 
     # Utility method; given a section index (index into the @section_names

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -274,6 +274,40 @@ subby=bar
       validate_file(expected_content, tmpfile)
     end
 
+    it "should treat a string indent_width as an integer" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => 'nonstandard',
+          :setting => 'indented', :value => 'weirdly',
+          :section_prefix => '-', :section_suffix => '-',
+          :indent_char => "\t", :indent_width => '4'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expected_content = <<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+				indented = weirdly
+      EOS
+      validate_file(expected_content, tmpfile)
+    end
+
     it "should add a missing setting to the correct section with colon" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => 'section:sub', :setting => 'yahoo', :value => 'yippee'))

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1352,9 +1352,9 @@ subby=bar
       validate_file(expected_content, tmpfile)
     end
 
-    it "should update an existing setting at the previous indentation regardless of indent_char setting" do
+    it "should update an existing setting at the previous indentation regardless of indent_char and indent_width settings" do
       resource = Puppet::Type::Ini_setting.new(
-          common_params.merge(:section => 'section:sub', :setting => 'fleezy', :value => 'flam2', :indent_char => 'ignore this'))
+          common_params.merge(:section => 'section:sub', :setting => 'fleezy', :value => 'flam2', :indent_char => 'ignore this', :indent_width => 10))
       provider = described_class.new(resource)
       expect(provider.exists?).to be true
       provider.create

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -206,6 +206,40 @@ subby=bar
       validate_file(expected_content, tmpfile)
     end
 
+    it "should add a missing setting to the correct section with indent" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => 'nonstandard',
+          :setting => 'indented', :value => 'weirdly',
+          :section_prefix => '-', :section_suffix => '-',
+          :indent => "\t"))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expected_content = <<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+		indented = weirdly
+      EOS
+      validate_file(expected_content, tmpfile)
+    end
+
     it "should add a missing setting to the correct section with colon" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => 'section:sub', :setting => 'yahoo', :value => 'yippee'))
@@ -1259,6 +1293,34 @@ subby=bar
     it "should update an existing setting at the previous indentation when the section is not aligned" do
       resource = Puppet::Type::Ini_setting.new(
           common_params.merge(:section => 'section:sub', :setting => 'fleezy', :value => 'flam2'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.create
+      expected_content = <<-EOS
+# This is a comment
+     [section1]
+     ; This is also a comment
+     foo=foovalue
+
+     bar = barvalue
+     master = true
+
+[section2]
+  foo= foovalue2
+  baz=bazvalue
+  url = http://192.168.1.1:8080
+[section:sub]
+ subby=bar
+    #another comment
+  fleezy = flam2
+ ; yet another comment
+      EOS
+      validate_file(expected_content, tmpfile)
+    end
+
+    it "should update an existing setting at the previous indentation regardless of indent setting" do
+      resource = Puppet::Type::Ini_setting.new(
+          common_params.merge(:section => 'section:sub', :setting => 'fleezy', :value => 'flam2', :indent => 'ignore this'))
       provider = described_class.new(resource)
       expect(provider.exists?).to be true
       provider.create

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -206,12 +206,12 @@ subby=bar
       validate_file(expected_content, tmpfile)
     end
 
-    it "should add a missing setting to the correct section with indent" do
+    it "should add a missing setting to the correct section with indent_char" do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(
           :section => 'nonstandard',
           :setting => 'indented', :value => 'weirdly',
           :section_prefix => '-', :section_suffix => '-',
-          :indent => "\t"))
+          :indent_char => "\t"))
       provider = described_class.new(resource)
       expect(provider.exists?).to be false
       provider.create
@@ -236,6 +236,40 @@ subby=bar
 -nonstandard-
   shoes = purple
 		indented = weirdly
+      EOS
+      validate_file(expected_content, tmpfile)
+    end
+
+    it "should add a missing setting to the correct section indented by indent_char * indent_width" do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(
+          :section => 'nonstandard',
+          :setting => 'indented', :value => 'weirdly',
+          :section_prefix => '-', :section_suffix => '-',
+          :indent_char => "\t", :indent_width => 4))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expected_content = <<-EOS
+# This is a comment
+[section1]
+; This is also a comment
+foo=foovalue
+
+bar = barvalue
+master = true
+[section2]
+
+foo= foovalue2
+baz=bazvalue
+url = http://192.168.1.1:8080
+[section:sub]
+subby=bar
+    #another comment
+ ; yet another comment
+
+-nonstandard-
+  shoes = purple
+				indented = weirdly
       EOS
       validate_file(expected_content, tmpfile)
     end
@@ -1318,9 +1352,9 @@ subby=bar
       validate_file(expected_content, tmpfile)
     end
 
-    it "should update an existing setting at the previous indentation regardless of indent setting" do
+    it "should update an existing setting at the previous indentation regardless of indent_char setting" do
       resource = Puppet::Type::Ini_setting.new(
-          common_params.merge(:section => 'section:sub', :setting => 'fleezy', :value => 'flam2', :indent => 'ignore this'))
+          common_params.merge(:section => 'section:sub', :setting => 'fleezy', :value => 'flam2', :indent_char => 'ignore this'))
       provider = described_class.new(resource)
       expect(provider.exists?).to be true
       provider.create


### PR DESCRIPTION
Add new params 'indent_char' and 'indent_width' which allow the character
used for indentation of newly-inserted values to be set instead of just using
a space, and for the width to be specified instead of computed. Some
software requires tabs in ini files, for example.

The default for 'indent_char' is ' ', and the default for 'indent_width' is undefined,
so the default behaviour is unchanged. Changing these params only affects
settings which are actually created. Settings which already exist and have a new value
will not be re-indented.

A limitation of this approach is that it will use whatever you specify
regardless of which characters the existing indentation uses. For example, if you
specify to use a tab and 2 spaces are detected, 2 tabs will be used for a new setting.
That's how it behaves now with spaces, it might just be less obvious when one is
specifying explicitly.