### PR TITLE
(MODULES-4932) fix for mimicking commented settings

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   end
 
   def create
-    ini_file.set_value(section, setting, resource[:value])
+    ini_file.set_value(section, setting, separator, resource[:value])
     ini_file.save
     @ini_file = nil
   end
@@ -58,7 +58,7 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   end
 
   def value=(value)
-    ini_file.set_value(section, setting, resource[:value])
+    ini_file.set_value(section, setting, separator, resource[:value])
     ini_file.save
   end
 

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
         subsetting, resource[:value], resource[:use_exact_match],
         resource[:insert_type], resource[:insert_value]
     )
-    ini_file.set_value(section, setting, setting_value.get_value)
+    ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
     ini_file.save
     @ini_file = nil
     @setting_value = nil
@@ -20,7 +20,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def destroy
     setting_value.remove_subsetting(subsetting, resource[:use_exact_match])
-    ini_file.set_value(section, setting, setting_value.get_value)
+    ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
     ini_file.save
     @ini_file = nil
     @setting_value = nil
@@ -35,7 +35,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
         subsetting, value, resource[:use_exact_match],
         resource[:insert_type], resource[:insert_value]
     )
-    ini_file.set_value(section, setting, setting_value.get_value)
+    ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
     ini_file.save
   end
 

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -63,7 +63,12 @@ module Util
       end
     end
 
-    def set_value(section_name, setting, value)
+    def set_value(section_name, setting, separator, value)
+      complete_setting = {
+        :setting => setting,
+        :separator => separator,
+        :value => value
+      }
       unless (@sections_hash.has_key?(section_name))
         add_section(Section.new(section_name, nil, nil, nil, nil))
       end
@@ -83,7 +88,7 @@ module Util
 
         # If we get here then we found a commented line, so we
         # call "insert_inline_setting_line" to update the lines array
-        insert_inline_setting_line(result, section, setting, value)
+        insert_inline_setting_line(result, section, complete_setting)
 
         # Then, we need to tell the setting object that we hacked
         # in an inline setting
@@ -292,10 +297,11 @@ module Util
     # This utility method is for inserting a line into the existing
     # lines array.  The `result` argument is expected to be in the
     # format of the return value of `find_commented_setting`.
-    def insert_inline_setting_line(result, section, setting, value)
+    def insert_inline_setting_line(result, section, complete_setting)
       line_num = result[:line_num]
       match = result[:match]
-      lines.insert(line_num + 1, "#{' ' * (section.indentation || 0 )}#{setting}#{match[4]}#{value}")
+      s = complete_setting
+      lines.insert(line_num + 1, "#{' ' * (section.indentation || 0 )}#{s[:setting]}#{s[:separator]}#{s[:value]}")
     end
 
     # Utility method; given a section index (index into the @section_names

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1361,7 +1361,7 @@ blah = blah
 [section2]
 # foo = foovalue
 ;bar=barvalue
-bar=bar3
+bar = bar3
 blah = blah
 #baz=
       EOS
@@ -1385,7 +1385,7 @@ blah = blah
 ;bar=barvalue
 blah = blah
 #baz=
-baz=bazvalue
+baz = bazvalue
       EOS
       validate_file(expected_content, tmpfile)
     end
@@ -1409,7 +1409,7 @@ EOS
         expected_content = <<-EOS
 [section1]
 # foo=foovalue
-foo=foovalue2
+foo = foovalue2
 # bar=bar2
         EOS
         validate_file(expected_content, tmpfile)
@@ -1426,7 +1426,7 @@ foo=foovalue2
 [section1]
 # foo=foovalue
 # bar=bar2
-bar=barvalue2
+bar = barvalue2
         EOS
         validate_file(expected_content, tmpfile)
       end

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -130,22 +130,22 @@ foo=
 
     it "should properly update uncommented values" do
       expect(subject.get_value("section1", "far")).to eq(nil)
-      subject.set_value("section1", "foo", "foovalue")
+      subject.set_value("section1", "foo", " = ", "foovalue")
       expect(subject.get_value("section1", "foo")).to eq("foovalue")
     end
 
     it "should properly update commented values" do
       expect(subject.get_value("section1", "bar")).to eq(nil)
-      subject.set_value("section1", "bar", "barvalue")
+      subject.set_value("section1", "bar", " = ", "barvalue")
       expect(subject.get_value("section1", "bar")).to eq("barvalue")
       expect(subject.get_value("section1", "xyzzy['thing1']['thing2']")).to eq(nil)
-      subject.set_value("section1", "xyzzy['thing1']['thing2']", "xyzzyvalue")
+      subject.set_value("section1", "xyzzy['thing1']['thing2']", " = ", "xyzzyvalue")
       expect(subject.get_value("section1", "xyzzy['thing1']['thing2']")).to eq("xyzzyvalue")
     end
 
     it "should properly add new empty values" do
       expect(subject.get_value("section1", "baz")).to eq(nil)
-      subject.set_value("section1", "baz", "bazvalue")
+      subject.set_value("section1", "baz", " = ", "bazvalue")
       expect(subject.get_value("section1", "baz")).to eq("bazvalue")
     end
   end


### PR DESCRIPTION
inifile, by design, looks for a commented version of a setting if an actual one does not exist. if one is found, it attempts to insert the new setting directly below its commented self and mimics the spacing used in the comment. this removes the mimicry and uses the designated key_val_separator instead.