### PR TITLE
(MODULES-5172) Backwards compatible ini_file.set_value

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -63,7 +63,15 @@ module Util
       end
     end
 
-    def set_value(section_name, setting, separator, value)
+    def set_value(*args)
+      case args.size
+      when 3
+        # Backwards compatible set_value function, See MODULES-5172
+        (section_name, setting, value) = args
+      when 4
+        (section_name, setting, separator, value) = args
+      end
+
       complete_setting = {
         :setting => setting,
         :separator => separator,

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -134,6 +134,12 @@ foo=
       expect(subject.get_value("section1", "foo")).to eq("foovalue")
     end
 
+    it "should properly update uncommented values without separator" do
+      expect(subject.get_value("section1", "far")).to eq(nil)
+      subject.set_value("section1", "foo", "foovalue")
+      expect(subject.get_value("section1", "foo")).to eq("foovalue")
+    end
+
     it "should properly update commented values" do
       expect(subject.get_value("section1", "bar")).to eq(nil)
       subject.set_value("section1", "bar", " = ", "barvalue")
@@ -143,9 +149,24 @@ foo=
       expect(subject.get_value("section1", "xyzzy['thing1']['thing2']")).to eq("xyzzyvalue")
     end
 
+    it "should properly update commented values without separator" do
+      expect(subject.get_value("section1", "bar")).to eq(nil)
+      subject.set_value("section1", "bar", "barvalue")
+      expect(subject.get_value("section1", "bar")).to eq("barvalue")
+      expect(subject.get_value("section1", "xyzzy['thing1']['thing2']")).to eq(nil)
+      subject.set_value("section1", "xyzzy['thing1']['thing2']", "xyzzyvalue")
+      expect(subject.get_value("section1", "xyzzy['thing1']['thing2']")).to eq("xyzzyvalue")
+    end
+
     it "should properly add new empty values" do
       expect(subject.get_value("section1", "baz")).to eq(nil)
       subject.set_value("section1", "baz", " = ", "bazvalue")
+      expect(subject.get_value("section1", "baz")).to eq("bazvalue")
+    end
+
+    it "should add new empty values without separator" do
+      expect(subject.get_value("section1", "baz")).to eq(nil)
+      subject.set_value("section1", "baz", "bazvalue")
       expect(subject.get_value("section1", "baz")).to eq("bazvalue")
     end
   end


### PR DESCRIPTION
The fix for MODULES-4932 (#239) was not backwards compatible as it changed the
number of required parameters for the set_value function in the ini_file
utility.  This breaks anyone who were also extending the ini_setting
providers and leveraging this function. This change updates the
set_value function to still work with the previous 3 parameters while
supporting the new format with 4 parameters.