### PR TITLE
Updates to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "10 SP4",
         "11 SP1",
         "12"
       ]
@@ -54,9 +53,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -70,14 +69,12 @@
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
         "10",
-        "11",
-        "12"
+        "11"
       ]
     },
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003 R2",
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2"


### PR DESCRIPTION
Removal of SLES 10, Debian 6 and Windows Server 2003. Addition of Debian
9. All changes are according to:
https://puppet.com/docs/pe/2017.3/installing/supported_operating_systems.html