### PR TITLE
(MODULES-6687) puppet bug fixed

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -89,7 +89,7 @@ Puppet::Type.newtype(:ini_setting) do
     end
 
     def insync?(current)
-      if @resource[:refreshonly]
+      if @resource[:refreshonly] && @resource[:refreshonly] != :false
         true
       else
         current == should


### PR DESCRIPTION
There was a bug in Puppet <= 5.4.0 where values of attributes could never be false. If set to false, they would actually just be nil, or they would be true. This has been fixed in 5.5.0 and requires the applied change in this module. @resource[:refreshonly] will no longer be set to nil, so only checking for its existence is not enough. Instead, also check to make sure it is not :false