### PR TITLE
(MODULES-6687) actually fix refreshonly issue

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -89,7 +89,7 @@ Puppet::Type.newtype(:ini_setting) do
     end
 
     def insync?(current)
-      if @resource[:refreshonly] && @resource[:refreshonly] != :false
+      if @resource[:refreshonly]
         true
       else
         current == should
@@ -120,11 +120,10 @@ Puppet::Type.newtype(:ini_setting) do
          'Defaults to undef (autodetect).'
   end
 
-  newparam(:refreshonly) do
+  newparam(:refreshonly, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc 'A flag indicating whether or not the ini_setting should be updated ' \
          'only when called as part of a refresh event'
     defaultto false
-    newvalues(true, false)
   end
 
   def refresh


### PR DESCRIPTION
Instead of trying to anticipate output in the validation step, this makes sure the param is turned into a boolean value before validation.