### PR TITLE
(FM-6932) - Fix type autoload

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:ini_setting) do
   ensurable do


### PR DESCRIPTION
The following errors were being seen:
```
[root@machine ~]# puppet describe ini_setting --trace
--
Error: Could not autoload puppet/type/ini_setting: uninitialized constant Puppet::Parameter::Boolean
/etc/puppetlabs/code/environments/production/modules/inifile/lib/puppet/type/ini_setting.rb:123:in `block in <top (required)>'
```
A require is necessary to initialize constant Puppet::Parameter::Boolean.

Now we can see:
```
[root@machine ~]# puppet describe ini_setting --trace

ini_setting
===========

Parameters
----------

- **ensure**
    The basic property that the resource should be in.
    Valid values are `present`, `absent`.
..................... etc
```