### PR TITLE
Handle backwards compatibility with force_new_section_creation

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -37,11 +37,19 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   def exists?
     if ini_file.section?(section)
       !ini_file.get_value(section, setting).nil?
-    elsif !resource[:force_new_section_creation]
+    elsif resource.parameters.keys.include?(:force_new_section_creation) && !resource[:force_new_section_creation]
+      # for backwards compatibility, if a user is using their own ini_setting
+      # types but does not have this parameter, we need to fall back to the
+      # previous functionality which was to create the section.  Anyone
+      # wishing to leverage this setting must define it in their provider
+      # type. See comments on
+      # https://github.com/puppetlabs/puppetlabs-inifile/pull/286
       resource[:ensure] = :absent
       resource[:force_new_section_creation]
-    else
+    elsif resource.parameters.keys.include?(:force_new_section_creation) && resource[:force_new_section_creation]
       !resource[:force_new_section_creation]
+    else
+      false
     end
   end
 


### PR DESCRIPTION
Prior to the introduction of this new parameter in the ini_setting type,
a user may have had their own custom type which implemented the required
parameters. The introduction of this new type would break anyone who was
not inheriting from the provide ini_setting type. This change adds a
check before looking for this option to allow those users to continue to
work.  If the force_new_section_creation is not defined on the type, the
previous expected functionality of automatic creation of the section
will occur.

Related-Bug: https://bugs.launchpad.net/puppet-openstacklib/+bug/1778247