### PR TITLE
(MODULES-8090) Add an autorequire to the parent directory of the path

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -136,4 +136,8 @@ Puppet::Type.newtype(:ini_setting) do
     # update the value in the provider, which will save the value to the ini file
     provider.value = self[:value] if self[:refreshonly]
   end
+
+  autorequire(:file) do
+    Pathname.new(self[:path]).parent.to_s
+  end
 end


### PR DESCRIPTION
This change simply adds an autorequire to the parent directory of the file specified in the `path` parameter. This is a small improvement for the users who create files exclusively from `ini_setting` resources as the file might not previously exist.