### PR TITLE
(MODULES-7560) - removed spaces from the beginning or from the end of the value

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -75,7 +75,11 @@ Puppet::Type.newtype(:ini_setting) do
     desc 'The value of the setting to be defined.'
 
     munge do |value|
-      value.to_s
+      if ([true, false].include? value) || value.is_a?(Numeric)
+        value.to_s
+      else
+        value.strip.to_s
+      end
     end
 
     def should_to_s(newvalue)

--- a/spec/acceptance/ini_setting_spec.rb
+++ b/spec/acceptance/ini_setting_spec.rb
@@ -322,4 +322,18 @@ describe 'ini_setting resource' do
       end
     end
   end
+
+  describe 'values with spaces in the value part at the beginning or at the end' do
+    pp = <<-EOS
+      ini_setting { 'path => foo':
+          ensure     => present,
+          section    => 'one',
+          setting    => 'two',
+          value      => '               123',
+          path       => '#{tmpdir}/ini_setting.ini',
+        }
+    EOS
+
+    it_behaves_like 'has_content', "#{tmpdir}/ini_setting.ini", pp, %r{\[one\]\ntwo = 123}
+  end
 end


### PR DESCRIPTION
When the value contains space characters at the beginning or at the end of the value, then the line will change at every puppet run. In order to fix it, i added strip to the value