### PR TITLE
(MODULES-6714) - inifile: ensure absent not working with refreshonly = true

### DIFF
--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -5,7 +5,19 @@ Puppet::Type.newtype(:ini_setting) do
   desc 'ini_settings is used to manage a single setting in an INI file'
   ensurable do
     desc 'Ensurable method handles modeling creation. It creates an ensure property'
-    defaultvalues
+    newvalue(:present) do
+      provider.create
+    end
+    newvalue(:absent) do
+      provider.destroy
+    end
+    def insync?(current)
+      if @resource[:refreshonly]
+        true
+      else
+        current == should
+      end
+    end
     defaultto :present
   end
 
@@ -130,6 +142,9 @@ Puppet::Type.newtype(:ini_setting) do
   end
 
   def refresh
+    if self[:ensure] == :absent && self[:refreshonly]
+      return provider.destroy
+    end
     # update the value in the provider, which will save the value to the ini file
     provider.value = self[:value] if self[:refreshonly]
   end


### PR DESCRIPTION
Solution:
Check for events before executing create, destroy or value update
Added acceptance tests for events

Problem description:
When removing a setting in a section with refreshonly set to true the setting is not completely removed. Only the value is removed.
Expect to remove the setting.
```
exec { 'testexec':
command => '/bin/true',
notify => Ini_Setting['testing'],
}

ini_setting { "testing":
ensure => absent,
path => '/tmp/t.txt',
section => 'section1',
setting => 'valueinsection1',
refreshonly => true,
}
```

What happened:
refreshonly was added specifically to refresh a value when there's an event that triggers a notification that is why the setting didn't get removed although the destroy method was triggered before the refreshonly (which only added back the setting with an empty value, because of this line:
`provider.value = self[:value] if self[:refreshonly]` and because the manifest which was supposed to remove the setting had no value defined, thus the empty string )

Upon further investigation even if an event was being triggered or not, the ini_setting manifest was going be executed. This is why I added the insync? method inside the ensurable block, we want to listen for an event if we're using refreshonly attribute, and only then execute, the manifest.


