### PR TITLE
(maint) Add HTML anchor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
+<a id="overview"></a>
 ## Overview
 
 The inifile module lets Puppet manage settings stored in INI-style configuration files.
 
+<a id="module-description"></a>
 ## Module Description
 
 Many applications use INI-style configuration files to store their settings. This module supplies two custom resource types to let you manage those settings through Puppet.
 
+<a id="setup"></a>
 ## Setup
 
 ### Beginning with inifile
@@ -36,6 +39,7 @@ ini_setting { "sample setting":
 }
 ~~~
 
+<a id="usage"></a>
 ## Usage
 
 
@@ -289,16 +293,18 @@ ini_setting { '[section1] setting3':
 }
 ~~~
 
-
+<a id="reference"></a> 
 ## Reference
 See [REFERENCE.md](https://github.com/puppetlabs/puppetlabs-inifile/blob/master/REFERENCE.md)
 
+<a id="limitations"></a>
 ## Limitations
 
 Due to (PUP-4709) the create_ini_settings function will cause errors when attempting to create multiple ini_settings in one go when using Puppet 4.0.x or 4.1.x. If needed, the temporary fix for this can be found here: https://github.com/puppetlabs/puppetlabs-inifile/pull/196.
 
 For an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-inifile/blob/master/metadata.json)
 
+<a id="development"></a> 
 ## Development
 
 Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.


### PR DESCRIPTION
The anchor tag helps fix broken links — If the header text changes (gets localized) the link will brake.