### PR TITLE
pdksync - Use abs instead of vmpooler to provision test resources

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -18,5 +18,5 @@ travis_el7:
   provisioner: docker
   images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7', 'litmusimage/scientificlinux:7']
 release_checks:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-5-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64','sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-2016-x86_64', 'win-2019-x86_64', 'win-10-pro-x86_64']

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,54 +1,6 @@
 # frozen_string_literal: true
 
-require 'serverspec'
 require 'puppet_litmus'
-require 'tmpdir'
-include PuppetLitmus
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
-if ENV['TARGET_HOST'].nil? || ENV['TARGET_HOST'] == 'localhost'
-  puts 'Running tests against this machine !'
-  if Gem.win_platform?
-    set :backend, :cmd
-  else
-    set :backend, :exec
-  end
-else
-  puts "TARGET_HOST #{ENV['TARGET_HOST']}"
-  # load inventory
-  inventory_hash = inventory_hash_from_inventory_file
-  node_config = config_from_node(inventory_hash, ENV['TARGET_HOST'])
-
-  if target_in_group(inventory_hash, ENV['TARGET_HOST'], 'ssh_nodes')
-    set :backend, :ssh
-    options = Net::SSH::Config.for(host)
-    options[:user] = node_config.dig('ssh', 'user') unless node_config.dig('ssh', 'user').nil?
-    options[:port] = node_config.dig('ssh', 'port') unless node_config.dig('ssh', 'port').nil?
-    options[:password] = node_config.dig('ssh', 'password') unless node_config.dig('ssh', 'password').nil?
-    host = if ENV['TARGET_HOST'].include?(':')
-             ENV['TARGET_HOST'].split(':').first
-           else
-             ENV['TARGET_HOST']
-           end
-    set :host,        options[:host_name] || host
-    set :ssh_options, options
-  elsif target_in_group(inventory_hash, ENV['TARGET_HOST'], 'winrm_nodes')
-    require 'winrm'
-
-    set :backend, :winrm
-    set :os, family: 'windows'
-    user = node_config.dig('winrm', 'user') unless node_config.dig('winrm', 'user').nil?
-    pass = node_config.dig('winrm', 'password') unless node_config.dig('winrm', 'password').nil?
-    endpoint = "http://#{ENV['TARGET_HOST']}:5985/wsman"
-
-    opts = {
-      user: user,
-      password: pass,
-      endpoint: endpoint,
-      operation_timeout: 300,
-    }
-
-    winrm = WinRM::Connection.new opts
-    Specinfra.configuration.winrm = winrm
-  end
-end
+PuppetLitmus.configure!

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require 'singleton'
+
+class LitmusHelper
+  include Singleton
+  include PuppetLitmus
+end
+
 def setup_test_directory
   basedir = case os[:family]
             when 'windows'
@@ -19,7 +26,7 @@ def setup_test_directory
       force   => true,
     }
   MANIFEST
-  apply_manifest(pp)
+  LitmusHelper.instance.apply_manifest(pp)
   basedir
 end
 
@@ -36,5 +43,5 @@ def setup_puppet_config_file
         force   => true,
       }
   MANIFEST
-  apply_manifest(config_pp)
+  LitmusHelper.instance.apply_manifest(config_pp)
 end


### PR DESCRIPTION
Use abs instead of vmpooler to provision test resources
pdk version: `1.17.0` 
