### PR TITLE
Add delete_if_empty parameter to the ini_subsetting type/provider

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -217,6 +217,14 @@ Default value: end
 
 The value for the insert types which require one.
 
+##### `delete_if_empty`
+
+Valid values: `true`, `false`
+
+Set to true to delete the parent setting when the subsetting is empty instead of writing an empty string
+
+Default value: `false`
+
 ## Functions
 
 ### create_ini_settings

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -24,7 +24,11 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def destroy
     setting_value.remove_subsetting(subsetting, resource[:use_exact_match])
-    ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
+    if setting_value.get_value.empty? && resource[:delete_if_empty]
+      ini_file.remove_setting(section, setting)
+    else
+      ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
+    end
     ini_file.save
     @ini_file = nil
     @setting_value = nil

--- a/lib/puppet/type/ini_subsetting.rb
+++ b/lib/puppet/type/ini_subsetting.rb
@@ -123,4 +123,10 @@ Puppet::Type.newtype(:ini_subsetting) do
   newparam(:insert_value) do
     desc 'The value for the insert types which require one.'
   end
+
+  newparam(:delete_if_empty) do
+    desc 'Set to true to delete the parent setting when the subsetting is empty instead of writing an empty string'
+    newvalues(:true, :false)
+    defaultto(:false)
+  end
 end

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -321,4 +321,41 @@ describe provider_class do
       validate_file(expected_content_four, tmpfile)
     end
   end
+
+  context 'when delete_if_empty is toggled to true' do
+    let(:common_params) do
+      {
+        title: 'ini_setting_delete_if_empty_test',
+        path: tmpfile,
+        section: 'master',
+        delete_if_empty: true,
+      }
+    end
+
+    let(:orig_content) do
+      <<-EOS
+        [master]
+        reports = http
+        something = else
+      EOS
+    end
+
+    expected_content_one = <<-EOS
+        [master]
+        something = else
+    EOS
+
+    expected_content_two = ''
+
+    it 'removes the subsetting when the it is empty' do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(setting: 'reports', subsetting: 'http', subsetting_separator: ','))
+      provider = described_class.new(resource)
+      provider.destroy
+      validate_file(expected_content_one, tmpfile)
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(setting: 'something', subsetting: 'else', subsetting_separator: ','))
+      provider = described_class.new(resource)
+      provider.destroy
+      validate_file(expected_content_two, tmpfile)
+    end
+  end
 end


### PR DESCRIPTION
Adds the capability to remove a parent setting when a subsetting is empty.

Example:
```
[one]
key = alphabet
key2 = moo
```

When the following Puppet resource is specified, the `key` is removed instead of being left empty:
```
ini_subsetting { 'ensure => absent for alpha':
  ensure          => absent,
  path            => "/tmp/inifile.ini",
  section         => 'one',
  setting         => 'key',
  subsetting      => 'alpha',
  delete_if_empty => true,
}
```

This results in:
```
[one]
key2 = moo
```

Instead of
```
[one]
key = 
key2 = moo
```