### PR TITLE
match section names containing prefix character (normally [)

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -31,19 +31,9 @@ module Puppet::Util
 
     def section_regex
       # Only put in prefix/suffix if they exist
-      # Also, if the prefix is '', the negated
-      # set match should be a match all instead.
       r_string = '^\s*'
       r_string += Regexp.escape(@section_prefix)
-      r_string += '('
-      if @section_prefix != ''
-        r_string += '[^'
-        r_string += Regexp.escape(@section_prefix)
-        r_string += ']'
-      else
-        r_string += '.'
-      end
-      r_string += '*)'
+      r_string += '(.*)'
       r_string += Regexp.escape(@section_suffix)
       r_string += '\s*$'
       %r{#{r_string}}


### PR DESCRIPTION
Currently sections with names including the prefix (normally [) can be
created by this provider, but they are then not matched by the regex,
meaning puppet will create a new section (with the same name) every time
it runs. Fix that by allowing the section prefix in the section name.
Any line that starts with the correct prefix (normally [) and ends with
the correct suffix (normally ]) is treated as a valid section header,
regardless of what is between them.

This is needed for splunk inputs.conf file where regexes, including
square brackets, are allowed inside the section name.