### PR TITLE
pdksync - (FM-8922) Add Support for Windows 2022

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,11 +78,12 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
+        "10",
         "2008 R2",
         "2012 R2",
         "2016",
         "2019",
-        "10"
+        "2022"
       ]
     },
     {


### PR DESCRIPTION
(FM-8922) Add Support for Windows 2022
pdk version: `2.1.0` 
