### PR TITLE
Add support for multiple values per key

### DIFF
--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -89,7 +89,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def setting_value
     @setting_value ||= Puppet::Util::SettingValue.new(
-      ini_file.get_value(section, setting),
+      Array(ini_file.get_value(section, setting))[0],
       subsetting_separator, quote_char, subsetting_key_val_separator
     )
   end

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(' = ')
   end
 
-  newproperty(:value, :array_matching => :all) do
+  newproperty(:value, array_matching: :all) do
     desc 'The value of the setting to be defined.'
 
     munge do |value|

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(' = ')
   end
 
-  newproperty(:value) do
+  newproperty(:value, :array_matching => :all) do
     desc 'The value of the setting to be defined.'
 
     munge do |value|

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -263,16 +263,15 @@ module Puppet::Util
       updated = false
       section.end_line.downto section.start_line do |line_num|
         next unless (match = @setting_regex.match(lines[line_num]))
-        if match[2] == setting
-          lines.delete_at(line_num)
+        next unless match[2] == setting
 
-          if !updated
-            value.each_with_index do |v, i|
-              lines.insert(line_num + i, "#{match[1]}#{match[2]}#{match[3]}#{v}")
-            end
-            updated = true
-          end
+        lines.delete_at(line_num)
+        next if updated
+
+        value.each_with_index do |v, i|
+          lines.insert(line_num + i, "#{match[1]}#{match[2]}#{match[3]}#{v}")
         end
+        updated = true
       end
     end
 

--- a/lib/puppet/util/ini_file/section.rb
+++ b/lib/puppet/util/ini_file/section.rb
@@ -54,11 +54,17 @@ class Puppet::Util::IniFile
     end
 
     def update_existing_setting(setting_name, value)
+      existing_value = @existing_settings[setting_name]
+
       @existing_settings[setting_name] = value
+
+      @end_line += value.length - existing_value.length
     end
 
     def remove_existing_setting(setting_name)
-      @end_line -= 1 if @existing_settings.delete(setting_name) && @end_line
+      existing_value = @existing_settings.delete(setting_name)
+
+      @end_line -= existing_value.length if existing_value && @end_line
     end
 
     # This is a hacky method; it's basically called when we need to insert
@@ -69,7 +75,7 @@ class Puppet::Util::IniFile
     # of the lines.
     def insert_inline_setting(setting_name, value)
       @existing_settings[setting_name] = value
-      @end_line += 1 if @end_line
+      @end_line += value.length if @end_line
     end
 
     def set_additional_setting(setting_name, value)
@@ -79,17 +85,17 @@ class Puppet::Util::IniFile
     # Decrement the start and end line numbers for the section (if they are
     # defined); this is intended to be called when a setting is removed
     # from a section that comes before this section in the ini file.
-    def decrement_line_nums
-      @start_line -= 1 if @start_line
-      @end_line -= 1 if @end_line
+    def decrement_line_nums(n = 1)
+      @start_line -= n if @start_line
+      @end_line -= n if @end_line
     end
 
     # Increment the start and end line numbers for the section (if they are
     # defined); this is intended to be called when an inline setting is added
     # to a section that comes before this section in the ini file.
-    def increment_line_nums
-      @start_line += 1 if @start_line
-      @end_line += 1 if @end_line
+    def increment_line_nums(n = 1)
+      @start_line += n if @start_line
+      @end_line += n if @end_line
     end
   end
 end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1589,7 +1589,7 @@ foo = bar
 
   context 'when using keys with multiple values' do
     let(:orig_content) do
-        <<-EOS
+      <<-EOS
 [section]
 foo = foovalue
 foo = foovalue2
@@ -1603,7 +1603,7 @@ bar = barvalue
 foo = value2
 
 [section3]
-        EOS
+      EOS
     end
 
     it 'retains an existing setting with setting the original value' do

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -49,16 +49,16 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #section1' do
-      expect(ini_sub.get_settings('section1')).to eq('bar' => 'barvalue',
-                                                     'baz' => '',
-                                                     'foo' => 'foovalue')
+      expect(ini_sub.get_settings('section1')).to eq('bar' => ['barvalue'],
+                                                     'baz' => [''],
+                                                     'foo' => ['foovalue'])
     end
     it 'exposes settings for sections #section2' do
-      expect(ini_sub.get_settings('section2')).to eq('baz' => 'bazvalue',
-                                                     'foo' => 'foovalue2',
-                                                     'l' => 'git log',
-                                                     "xyzzy['thing1']['thing2']" => 'xyzzyvalue',
-                                                     'zot' => 'multi word value')
+      expect(ini_sub.get_settings('section2')).to eq('baz' => ['bazvalue'],
+                                                     'foo' => ['foovalue2'],
+                                                     'l' => ['git log'],
+                                                     "xyzzy['thing1']['thing2']" => ['xyzzyvalue'],
+                                                     'zot' => ['multi word value'])
     end
   end
 
@@ -83,7 +83,7 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections' do
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
   end
 
@@ -109,10 +109,10 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #bar' do
-      expect(ini_sub.get_value('', 'foo')).to eq('bar')
+      expect(ini_sub.get_value('', 'foo')).to eq(['bar'])
     end
     it 'exposes settings for sections #foovalue' do
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
   end
 
@@ -136,42 +136,42 @@ describe Puppet::Util::IniFile do
 
     it 'properlies update uncommented values' do
       ini_sub.set_value('section1', 'foo', ' = ', 'foovalue')
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
 
     it 'properlies update uncommented values without separator' do
       ini_sub.set_value('section1', 'foo', 'foovalue')
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
 
     it 'properlies update commented value' do
       ini_sub.set_value('section1', 'bar', ' = ', 'barvalue')
-      expect(ini_sub.get_value('section1', 'bar')).to eq('barvalue')
+      expect(ini_sub.get_value('section1', 'bar')).to eq(['barvalue'])
     end
 
     it 'properlies update commented values' do
       ini_sub.set_value('section1', "xyzzy['thing1']['thing2']", ' = ', 'xyzzyvalue')
-      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq('xyzzyvalue')
+      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq(['xyzzyvalue'])
     end
 
     it 'properlies update commented value without separator' do
       ini_sub.set_value('section1', 'bar', 'barvalue')
-      expect(ini_sub.get_value('section1', 'bar')).to eq('barvalue')
+      expect(ini_sub.get_value('section1', 'bar')).to eq(['barvalue'])
     end
 
     it 'properlies update commented values without separator' do
       ini_sub.set_value('section1', "xyzzy['thing1']['thing2']", 'xyzzyvalue')
-      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq('xyzzyvalue')
+      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq(['xyzzyvalue'])
     end
 
     it 'properlies add new empty values' do
       ini_sub.set_value('section1', 'baz', ' = ', 'bazvalue')
-      expect(ini_sub.get_value('section1', 'baz')).to eq('bazvalue')
+      expect(ini_sub.get_value('section1', 'baz')).to eq(['bazvalue'])
     end
 
     it 'adds new empty values without separator' do
       ini_sub.set_value('section1', 'baz', 'bazvalue')
-      expect(ini_sub.get_value('section1', 'baz')).to eq('bazvalue')
+      expect(ini_sub.get_value('section1', 'baz')).to eq(['bazvalue'])
     end
   end
 
@@ -258,10 +258,10 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #print' do
-      expect(ini_sub.get_value('khotkeys', '{5465e8c7-d608-4493-a48f-b99d99fdb508}')).to eq('Print,none,PrintScreen')
+      expect(ini_sub.get_value('khotkeys', '{5465e8c7-d608-4493-a48f-b99d99fdb508}')).to eq(['Print,none,PrintScreen'])
     end
     it 'exposes settings for sections #search' do
-      expect(ini_sub.get_value('khotkeys', '{d03619b6-9b3c-48cc-9d9c-a2aadb485550}')).to eq('Search,none,Search')
+      expect(ini_sub.get_value('khotkeys', '{d03619b6-9b3c-48cc-9d9c-a2aadb485550}')).to eq(['Search,none,Search'])
     end
   end
 
@@ -277,13 +277,13 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #A' do
-      expect(ini_sub.get_value('Drive names', 'A:')).to eq '5.25" Floppy'
+      expect(ini_sub.get_value('Drive names', 'A:')).to eq ['5.25" Floppy']
     end
     it 'exposes settings for sections #B' do
-      expect(ini_sub.get_value('Drive names', 'B:')).to eq '3.5" Floppy'
+      expect(ini_sub.get_value('Drive names', 'B:')).to eq ['3.5" Floppy']
     end
     it 'exposes settings for sections #C' do
-      expect(ini_sub.get_value('Drive names', 'C:')).to eq 'Winchester'
+      expect(ini_sub.get_value('Drive names', 'C:')).to eq ['Winchester']
     end
   end
 
@@ -302,16 +302,48 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #log' do
-      expect(ini_sub.get_value('global', 'log file')).to eq '/var/log/samba/log.%m'
+      expect(ini_sub.get_value('global', 'log file')).to eq ['/var/log/samba/log.%m']
     end
     it 'exposes settings for sections #kerberos' do
-      expect(ini_sub.get_value('global', 'kerberos method')).to eq 'system keytab'
+      expect(ini_sub.get_value('global', 'kerberos method')).to eq ['system keytab']
     end
     it 'exposes settings for sections #passdb' do
-      expect(ini_sub.get_value('global', 'passdb backend')).to eq 'tdbsam'
+      expect(ini_sub.get_value('global', 'passdb backend')).to eq ['tdbsam']
     end
     it 'exposes settings for sections #security' do
-      expect(ini_sub.get_value('global', 'security')).to eq 'ads'
+      expect(ini_sub.get_value('global', 'security')).to eq ['ads']
+    end
+  end
+
+  context 'when using keys with multiple values' do
+    let(:sample_content) do
+      template = <<-EOS
+        [section]
+        foo=value1
+        foo=value2
+        bar=barvalue
+      EOS
+      template.split("\n")
+    end
+
+    it 'exposes settings for section #section' do
+      expect(ini_sub.get_settings('section')).to eq('foo' => ['value1', 'value2'],
+                                                    'bar' => ['barvalue'])
+    end
+
+    it 'adds multiple values' do
+      ini_sub.set_value('section', 'baz', ['bazvalue', 'bazvalue2'])
+      expect(ini_sub.get_value('section', 'baz')).to eq(['bazvalue', 'bazvalue2'])
+    end
+
+    it 'updates multiple values' do
+      ini_sub.set_value('section', 'bar', ['barvalue', 'barvalue2'])
+      expect(ini_sub.get_value('section', 'bar')).to eq(['barvalue', 'barvalue2'])
+    end
+
+    it 'removes extra values' do
+      ini_sub.set_value('section', 'foo', 'value2')
+      expect(ini_sub.get_value('section', 'foo')).to eq(['value2'])
     end
   end
 end


### PR DESCRIPTION
This change adds support for ini files in which the same key is used multiple times for lists of values, for example:
```
[section]
foo=a
foo=b
```
To set multiple values, an array of values can be passed to the `value` property of `ini_setting`.

When passing a single value, the module works as before, with one exception: when a single value is passed to `value`, but the ini file already contains multiple lines with the same key, any additional lines will now be removed instead of retained.