### PR TITLE
Fix broken idempotency with empty sections

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -32,8 +32,9 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   end
 
   def exists?
-    setting.nil? && ini_file.section_names.include?(section) || !ini_file.get_value(section, setting).nil?
-    if ini_file.section?(section)
+    if setting.nil?
+      ini_file.section_names.include?(section)
+    elsif ini_file.section?(section)
       !ini_file.get_value(section, setting).nil?
     elsif resource.parameters.key?(:force_new_section_creation) && !resource[:force_new_section_creation]
       # for backwards compatibility, if a user is using their own ini_setting

--- a/spec/acceptance/ini_setting_spec.rb
+++ b/spec/acceptance/ini_setting_spec.rb
@@ -162,6 +162,18 @@ describe 'ini_setting resource' do
     end
   end
 
+  context 'ensure parameter => present and only section' do
+    pp = <<-EOS
+    ini_setting { 'ensure => present for section':
+      ensure  => present,
+      path    => "#{basedir}/ini_setting.ini",
+      section => 'one',
+    }
+    EOS
+
+    it_behaves_like 'has_content', "#{basedir}/ini_setting.ini", pp, %r{\[one\]}
+  end
+
   describe 'show_diff parameter and logging:' do
     setup_puppet_config_file
 


### PR DESCRIPTION
This change fixes idempotency of the ini_setting resource type used to
manage an empty section (a section without any prameters), which was
introduced by commit 8a46c6d20f6b57609043ade27b571db91cef3a19 .

Fixes #482