### PR TITLE
(MAINT) Drop support for Solaris 10, Windows Server 2008 R2, and AIX 5.3 and 6.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,6 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },
@@ -78,7 +77,6 @@
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
         "10",
-        "2008 R2",
         "2012 R2",
         "2016",
         "2019",
@@ -88,8 +86,6 @@
     {
       "operatingsystem": "AIX",
       "operatingsystemrelease": [
-        "5.3",
-        "6.1",
         "7.1"
       ]
     },


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
Support for Solaris 10 was removed.
Support for Windows Server 2008 R2 was removed.
Support for AIX 5.3 and 6.1 was removed.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html