### PR TITLE
(CAT-1646) - Remove section if it has empty line but does not have any settings 

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -222,6 +222,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
       end_line_num = start_line
       min_indentation = nil
       empty = true
+      empty_line_count = 0
       loop do
         line, line_num = line_iter.peek
         if line_num.nil? || @section_regex.match(line)
@@ -229,7 +230,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
           # when it's empty, we must be sure it's thought of as new,
           # which is signalled with a nil ending line
           end_line_num = nil if name == '' && empty
-          return Section.new(name, start_line, end_line_num, settings, min_indentation)
+          return Section.new(name, start_line, end_line_num, settings, min_indentation, empty_line_count)
         end
         if (match = @setting_regex.match(line))
           settings[match[2]] = match[4]
@@ -237,6 +238,8 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
           min_indentation = [indentation, min_indentation || indentation].min
         end
         end_line_num = line_num
+        empty_line_count += 1 if line == "\n"
+
         empty = false
         line_iter.next
       end

--- a/lib/puppet/util/ini_file/section.rb
+++ b/lib/puppet/util/ini_file/section.rb
@@ -14,13 +14,14 @@ class Puppet::Util::IniFile # rubocop:disable Style/ClassAndModuleChildren
     #    `end_line` of `nil`.
     #  * `start_line` and `end_line` will be set to `nil` for a new non-global
     #    section.
-    def initialize(name, start_line, end_line, settings, indentation)
+    def initialize(name, start_line, end_line, settings, indentation, empty_line_count = 0)
       @name = name
       @start_line = start_line
       @end_line = end_line
       @existing_settings = settings.nil? ? {} : settings
       @additional_settings = {}
       @indentation = indentation
+      @empty_line_count = empty_line_count
     end
 
     attr_reader :name, :start_line, :end_line, :additional_settings, :indentation
@@ -50,7 +51,7 @@ class Puppet::Util::IniFile # rubocop:disable Style/ClassAndModuleChildren
     # the global section is empty whenever it's new;
     # other sections are empty when they have no lines
     def empty?
-      global? ? new_section? : start_line == end_line
+      global? ? new_section? : (start_line == end_line || (end_line && (end_line - @empty_line_count)) == start_line)
     end
 
     def update_existing_setting(setting_name, value)

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1141,6 +1141,38 @@ setting1 = hellowworld
     end
   end
 
+  context 'when section has only empty line' do
+    let(:orig_content) do
+      <<~INIFILE
+        [section1]
+        foo=foovalue
+
+
+        [section2]
+
+        foo= foovalue2
+        baz=bazvalue
+        url = http://
+      INIFILE
+    end
+
+    expected_content = <<~INIFILE
+      [section2]
+
+      foo= foovalue2
+      baz=bazvalue
+      url = http://
+    INIFILE
+
+    it 'remove empty section' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section1', setting: 'foo', ensure: 'absent'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.destroy
+      validate_file(expected_content, tmpfile)
+    end
+  end
+
   context 'when dealing with indentation in sections' do
     let(:orig_content) do
       <<~INIFILE


### PR DESCRIPTION
## Summary

Current implementation keeping section as it is if just contain empty line as described [here](https://github.com/puppetlabs/puppetlabs-inifile/issues/524), this change will delete the section if just contain empty line.


## Related Issues (if any)

https://github.com/puppetlabs/puppetlabs-inifile/issues/524

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)