### PR TITLE
Honor default separator in set_config

### DIFF
--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -63,6 +63,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
       when 3
         # Backwards compatible set_value function, See MODULES-5172
         (section_name, setting, value) = args
+        separator = @key_val_separator
       when 4
         (section_name, setting, separator, value) = args
       end


### PR DESCRIPTION
... to use the consistent separator by default in all functions by default. Users can still override the separator by passing the separator argument when calling the function.

Fixes: #544

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
#544

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)