### PR TITLE
Add support for multiple values per key

### DIFF
--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -89,7 +89,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
 
   def setting_value
     @setting_value ||= Puppet::Util::SettingValue.new(
-      ini_file.get_value(section, setting),
+      Array(ini_file.get_value(section, setting))[0],
       subsetting_separator, quote_char, subsetting_key_val_separator
     )
   end

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(' = ')
   end
 
-  newproperty(:value, :array_matching => :all) do
+  newproperty(:value, array_matching: :all) do
     desc 'The value of the setting to be defined.'
 
     munge do |value|

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:ini_setting) do
     defaultto(' = ')
   end
 
-  newproperty(:value) do
+  newproperty(:value, :array_matching => :all) do
     desc 'The value of the setting to be defined.'
 
     munge do |value|

--- a/lib/puppet/type/ini_setting.rb
+++ b/lib/puppet/type/ini_setting.rb
@@ -94,6 +94,7 @@ Puppet::Type.newtype(:ini_setting) do
     end
 
     def should_to_s(newvalue)
+      newvalue = newvalue.first if newvalue.is_a?(Array) && newvalue.length == 1
       if @resource[:show_diff] == :true && Puppet[:show_diff]
         newvalue
       elsif @resource[:show_diff] == :md5 && Puppet[:show_diff]

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -67,6 +67,8 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
         (section_name, setting, separator, value) = args
       end
 
+      value = [*value]
+
       complete_setting = {
         setting: setting,
         separator: separator,
@@ -77,8 +79,17 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
       section = @sections_hash[section_name]
 
       if section.existing_setting?(setting)
+        existing_value = section.get_value(setting)
+        section_index = @section_names.index(section_name)
+
         update_line(section, setting, value)
         section.update_existing_setting(setting, value)
+
+        if value.length > existing_value.length
+          increment_section_line_numbers(section_index + 1, value.length - existing_value.length)
+        elsif value.length < existing_value.length
+          decrement_section_line_numbers(section_index + 1, existing_value.length - value.length)
+        end
       elsif find_commented_setting(section, setting)
         # So, this stanza is a bit of a hack.  What we're trying
         # to do here is this: for settings that don't already
@@ -99,7 +110,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
         # numbers for all of the sections *after* the one that
         # was modified.
         section_index = @section_names.index(section_name)
-        increment_section_line_numbers(section_index + 1)
+        increment_section_line_numbers(section_index + 1, value.length)
       elsif !setting.nil? || !value.nil?
         section.set_additional_setting(setting, value)
       end
@@ -108,6 +119,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
     def remove_setting(section_name, setting)
       section = @sections_hash[section_name]
       return unless section.existing_setting?(setting)
+      existing_value = section.get_value(setting)
 
       # If the setting is found, we have some work to do.
       # First, we remove the line from our array of lines:
@@ -121,7 +133,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
       # numbers for all of the sections *after* the one that
       # was modified.
       section_index = @section_names.index(section_name)
-      decrement_section_line_numbers(section_index + 1)
+      decrement_section_line_numbers(section_index + 1, existing_value.length)
     end
 
     def save
@@ -164,7 +176,9 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
 
           # write new settings, if there are any
           section.additional_settings.each_pair do |key, value|
-            fh.puts("#{@indent_char * (@indent_width || section.indentation || 0)}#{key}#{@key_val_separator}#{value}")
+            value.each do |v|
+              fh.puts("#{@indent_char * (@indent_width || section.indentation || 0)}#{key}#{@key_val_separator}#{v}")
+            end
           end
 
           if !whitespace_buffer.empty?
@@ -224,7 +238,7 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
           return Section.new(name, start_line, end_line_num, settings, min_indentation)
         end
         if (match = @setting_regex.match(line))
-          settings[match[2]] = match[4]
+          (settings[match[2]] ||= []).push(match[4])
           indentation = match[1].length
           min_indentation = [indentation, min_indentation || indentation].min
         end
@@ -235,15 +249,24 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
     end
 
     def update_line(section, setting, value)
-      (section.start_line..section.end_line).each do |line_num|
+      updated = false
+      section.end_line.downto section.start_line do |line_num|
         next unless (match = @setting_regex.match(lines[line_num]))
+        if match[2] == setting
+          lines.delete_at(line_num)
 
-        lines[line_num] = "#{match[1]}#{match[2]}#{match[3]}#{value}" if match[2] == setting
+          if !updated
+            value.each_with_index do |v, i|
+              lines.insert(line_num + i, "#{match[1]}#{match[2]}#{match[3]}#{v}")
+            end
+            updated = true
+          end
+        end
       end
     end
 
     def remove_line(section, setting)
-      (section.start_line..section.end_line).each do |line_num|
+      section.end_line.downto section.start_line do |line_num|
         next unless (match = @setting_regex.match(lines[line_num]))
 
         lines.delete_at(line_num) if match[2] == setting
@@ -294,26 +317,28 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
     def insert_inline_setting_line(result, section, complete_setting)
       line_num = result[:line_num]
       s = complete_setting
-      lines.insert(line_num + 1, "#{@indent_char * (@indent_width || section.indentation || 0)}#{s[:setting]}#{s[:separator]}#{s[:value]}")
+      s[:value].each_with_index do |v, i|
+        lines.insert(line_num + 1 + i, "#{@indent_char * (@indent_width || section.indentation || 0)}#{s[:setting]}#{s[:separator]}#{v}")
+      end
     end
 
     # Utility method; given a section index (index into the @section_names
     # array), decrement the start/end line numbers for that section and all
     # all of the other sections that appear *after* the specified section.
-    def decrement_section_line_numbers(section_index)
+    def decrement_section_line_numbers(section_index, n = 1)
       @section_names[section_index..(@section_names.length - 1)].each do |name|
         section = @sections_hash[name]
-        section.decrement_line_nums
+        section.decrement_line_nums(n)
       end
     end
 
     # Utility method; given a section index (index into the @section_names
     # array), increment the start/end line numbers for that section and all
     # all of the other sections that appear *after* the specified section.
-    def increment_section_line_numbers(section_index)
+    def increment_section_line_numbers(section_index, n = 1)
       @section_names[section_index..(@section_names.length - 1)].each do |name|
         section = @sections_hash[name]
-        section.increment_line_nums
+        section.increment_line_nums(n)
       end
     end
 

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -252,16 +252,15 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
       updated = false
       section.end_line.downto section.start_line do |line_num|
         next unless (match = @setting_regex.match(lines[line_num]))
-        if match[2] == setting
-          lines.delete_at(line_num)
+        next unless match[2] == setting
 
-          if !updated
-            value.each_with_index do |v, i|
-              lines.insert(line_num + i, "#{match[1]}#{match[2]}#{match[3]}#{v}")
-            end
-            updated = true
-          end
+        lines.delete_at(line_num)
+        next if updated
+
+        value.each_with_index do |v, i|
+          lines.insert(line_num + i, "#{match[1]}#{match[2]}#{match[3]}#{v}")
         end
+        updated = true
       end
     end
 

--- a/lib/puppet/util/ini_file/section.rb
+++ b/lib/puppet/util/ini_file/section.rb
@@ -54,11 +54,17 @@ class Puppet::Util::IniFile # rubocop:disable Style/ClassAndModuleChildren
     end
 
     def update_existing_setting(setting_name, value)
+      existing_value = @existing_settings[setting_name]
+
       @existing_settings[setting_name] = value
+
+      @end_line += value.length - existing_value.length
     end
 
     def remove_existing_setting(setting_name)
-      @end_line -= 1 if @existing_settings.delete(setting_name) && @end_line
+      existing_value = @existing_settings.delete(setting_name)
+
+      @end_line -= existing_value.length if existing_value && @end_line
     end
 
     # This is a hacky method; it's basically called when we need to insert
@@ -69,7 +75,7 @@ class Puppet::Util::IniFile # rubocop:disable Style/ClassAndModuleChildren
     # of the lines.
     def insert_inline_setting(setting_name, value)
       @existing_settings[setting_name] = value
-      @end_line += 1 if @end_line
+      @end_line += value.length if @end_line
     end
 
     def set_additional_setting(setting_name, value)
@@ -79,17 +85,17 @@ class Puppet::Util::IniFile # rubocop:disable Style/ClassAndModuleChildren
     # Decrement the start and end line numbers for the section (if they are
     # defined); this is intended to be called when a setting is removed
     # from a section that comes before this section in the ini file.
-    def decrement_line_nums
-      @start_line -= 1 if @start_line
-      @end_line -= 1 if @end_line
+    def decrement_line_nums(n = 1)
+      @start_line -= n if @start_line
+      @end_line -= n if @end_line
     end
 
     # Increment the start and end line numbers for the section (if they are
     # defined); this is intended to be called when an inline setting is added
     # to a section that comes before this section in the ini file.
-    def increment_line_nums
-      @start_line += 1 if @start_line
-      @end_line += 1 if @end_line
+    def increment_line_nums(n = 1)
+      @start_line += n if @start_line
+      @end_line += n if @end_line
     end
   end
 end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -92,13 +92,13 @@ describe provider_class do
         expect(child_three).to receive(:file_path).twice.and_return(tmpfile)
         expect(child_three.instances.size).to eq(7)
         expected_array = [
-          { name: 'section1/foo', value: 'foovalue' },
-          { name: 'section1/bar', value: 'barvalue' },
-          { name: 'section1/main', value: 'true' },
-          { name: 'section2/foo', value: 'foovalue2' },
-          { name: 'section2/baz', value: 'bazvalue' },
-          { name: 'section2/url', value: 'http://192.168.1.1:8080' },
-          { name: 'section:sub/subby', value: 'bar' },
+          { name: 'section1/foo', value: ['foovalue'] },
+          { name: 'section1/bar', value: ['barvalue'] },
+          { name: 'section1/main', value: ['true'] },
+          { name: 'section2/foo', value: ['foovalue2'] },
+          { name: 'section2/baz', value: ['bazvalue'] },
+          { name: 'section2/url', value: ['http://192.168.1.1:8080'] },
+          { name: 'section:sub/subby', value: ['bar'] },
         ]
         real_array = []
         ensure_array = []
@@ -433,7 +433,7 @@ describe provider_class do
     it 'modifies an existing setting with a different value - with colon in section' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section:sub', setting: 'subby', value: 'foo'))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('bar')
+      expect(provider.value).to eq(['bar'])
       provider.value = 'foo'
       validate_file(expected_content_ten, tmpfile)
     end
@@ -462,7 +462,7 @@ describe provider_class do
     it 'is able to handle settings with non alphanumbering settings' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(setting: 'url', value: 'http://192.168.0.1:8080'))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('http://192.168.1.1:8080')
+      expect(provider.value).to eq(['http://192.168.1.1:8080'])
       provider.value = 'http://192.168.0.1:8080'
       validate_file(expected_content_eleven, tmpfile)
     end
@@ -491,7 +491,7 @@ describe provider_class do
     it 'is able to handle settings with pre/suffix with non alphanumbering settings' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'nonstandard', setting: 'shoes', value: 'http://192.168.0.1:8080', section_prefix: '-', section_suffix: '-'))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('purple')
+      expect(provider.value).to eq(['purple'])
       provider.value = 'http://192.168.0.1:8080'
       validate_file(expected_content_twelve, tmpfile)
     end
@@ -648,7 +648,7 @@ describe provider_class do
     it 'is able to handle variables of any type' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section1', setting: 'main', value: true))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('true')
+      expect(provider.value).to eq(['true'])
     end
   end
 
@@ -770,7 +770,7 @@ setting1 = hellowworld
     it 'modifies an existing setting with a different value' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: '', setting: 'foo', value: 'yippee'))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('blah')
+      expect(provider.value).to eq(['blah'])
       provider.value = 'yippee'
       validate_file(expected_content_two, tmpfile)
     end
@@ -811,7 +811,7 @@ setting1 = hellowworld
     it 'modifies an existing setting' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section2', setting: 'foo', value: 'yippee'))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('http://192.168.1.1:8080')
+      expect(provider.value).to eq(['http://192.168.1.1:8080'])
       provider.value = 'yippee'
       validate_file(expected_content_two, tmpfile)
     end
@@ -845,7 +845,7 @@ setting1 = hellowworld
     it 'modifies an existing setting' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section2', setting: 'foo', value: 'yippee', key_val_separator: '='))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('bar')
+      expect(provider.value).to eq(['bar'])
       provider.value = 'yippee'
       validate_file(expected_content_one, tmpfile)
     end
@@ -866,7 +866,7 @@ setting1 = hellowworld
     it 'modifies an existing setting' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section2', setting: 'foo', value: 'yippee', key_val_separator: ': '))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('bar')
+      expect(provider.value).to eq(['bar'])
       provider.value = 'yippee'
       validate_file(expected_content_one, tmpfile)
     end
@@ -900,7 +900,7 @@ setting1 = hellowworld
     it 'modifies an existing setting' do
       resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section2', setting: 'foo', value: 'yippee', key_val_separator: ' '))
       provider = described_class.new(resource)
-      expect(provider.value).to eq('bar')
+      expect(provider.value).to eq(['bar'])
       provider.value = 'yippee'
       validate_file(expected_content_one, tmpfile)
     end
@@ -1550,4 +1550,130 @@ setting1 = hellowworld
       validate_file(expected_content_one, tmpfile)
     end
   end
+
+  context 'when using keys with multiple values' do
+    let(:orig_content) do
+        <<-EOS
+[section]
+foo = foovalue
+foo = foovalue2
+foo = foovalue3
+foo = foovalue4
+bar = barvalue
+
+[section2]
+foo = value
+bar = barvalue
+foo = value2
+
+[section3]
+        EOS
+    end
+
+    it 'retains an existing setting with setting the original value' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section', setting: 'foo', value: ['foovalue', 'foovalue2', 'foovalue3', 'foovalue4']))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.create
+      validate_file(orig_content, tmpfile)
+    end
+
+    expected_content_one = <<-EOS
+[section]
+foo = foovalue
+bar = barvalue
+
+[section2]
+foo = value
+bar = barvalue
+foo = value2
+
+[section3]
+    EOS
+
+    it 'removes additional values from an existing setting' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section', setting: 'foo', value: 'foovalue'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.create
+      validate_file(expected_content_one, tmpfile)
+    end
+
+    expected_content_two = <<-EOS
+[section]
+foo = foovalue
+foo = foovalue2
+foo = foovalue3
+foo = foovalue4
+bar = barvalue
+
+[section2]
+bar = barvalue
+foo = value
+foo = value2
+foo = value3
+
+[section3]
+    EOS
+
+    it 'adds new values to an existing setting' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section2', setting: 'foo', value: ['value', 'value2', 'value3']))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.create
+      validate_file(expected_content_two, tmpfile)
+    end
+
+    expected_content_three = <<-EOS
+[section]
+foo = foovalue2
+foo = foovalue4
+foo = foovalue
+foo = foovalue3
+bar = barvalue
+
+[section2]
+foo = value
+bar = barvalue
+foo = value2
+
+[section3]
+    EOS
+
+    it 'modifies an existing setting with values ordered differently' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section', setting: 'foo', value: ['foovalue2', 'foovalue4', 'foovalue', 'foovalue3']))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.create
+      validate_file(expected_content_three, tmpfile)
+    end
+
+    expected_content_four = <<-EOS
+[section]
+foo = foovalue
+foo = foovalue2
+foo = foovalue3
+foo = foovalue4
+bar = barvalue
+
+[section2]
+foo = value
+bar = barvalue
+foo = value2
+
+[section3]
+foo = a
+foo = b
+foo = c
+    EOS
+
+    it 'adds a new setting' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section3', setting: 'foo', value: ['a', 'b', 'c']))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      validate_file(expected_content_four, tmpfile)
+    end
+  end
+
 end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1553,7 +1553,7 @@ setting1 = hellowworld
 
   context 'when using keys with multiple values' do
     let(:orig_content) do
-        <<-EOS
+      <<-EOS
 [section]
 foo = foovalue
 foo = foovalue2
@@ -1567,7 +1567,7 @@ bar = barvalue
 foo = value2
 
 [section3]
-        EOS
+      EOS
     end
 
     it 'retains an existing setting with setting the original value' do

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1675,5 +1675,4 @@ foo = c
       validate_file(expected_content_four, tmpfile)
     end
   end
-
 end

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1674,5 +1674,61 @@ foo = c
       provider.create
       validate_file(expected_content_four, tmpfile)
     end
+
+    expected_content_five = <<-EOS
+[section]
+bar = barvalue
+
+[section2]
+foo = value
+bar = barvalue
+foo = value2
+
+[section3]
+    EOS
+
+    it 'removes a multi-value setting with ensure => absent' do
+      resource = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section', setting: 'foo', ensure: 'absent'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.destroy
+      validate_file(expected_content_five, tmpfile)
+    end
+
+    expected_content_six = <<-EOS
+[section]
+foo = foovalue
+foo = foovalue2
+foo = foovalue3
+foo = foovalue4
+bar = barvalue
+
+[section2]
+foo = value
+bar = barvalue
+foo = value2
+
+[section3]
+baz = newvalue
+    EOS
+
+    it 'correctly updates section3 line numbers after modifying section with multi-values' do
+      # First reduce section's foo from 4 values to 1, then add to section3
+      resource1 = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section', setting: 'foo', value: 'foovalue'))
+      provider1 = described_class.new(resource1)
+      provider1.create
+
+      # Re-read the file with new provider to add setting to section3
+      resource2 = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section3', setting: 'baz', value: 'newvalue'))
+      provider2 = described_class.new(resource2)
+      provider2.create
+
+      # Now reset file and do both operations to verify section line tracking
+      File.write(tmpfile, orig_content)
+      resource3 = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section3', setting: 'baz', value: 'newvalue'))
+      provider3 = described_class.new(resource3)
+      provider3.create
+      validate_file(expected_content_six, tmpfile)
+    end
   end
 end

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -360,4 +360,60 @@ describe provider_class do
       expect(validate_file(expected_content_two, tmpfile)).to be_truthy
     end
   end
+
+  context 'when the parent setting has multiple values (same key repeated)' do
+    let(:common_params) do
+      {
+        title: 'ini_subsetting_multivalue_test',
+        path: tmpfile,
+        section: 'main',
+        key_val_separator: '=',
+      }
+    end
+
+    let(:orig_content) do
+      <<-INIFILE
+        [main]
+        setting="value1 value2"
+        setting="value3 value4"
+        other=data
+      INIFILE
+    end
+
+    it 'reads subsetting from the first occurrence of a multi-value key' do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(setting: 'setting', subsetting: 'value1', quote_char: '"'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to eq ''
+    end
+
+    # NOTE: When ini_subsetting modifies a key that has multiple values,
+    # it collapses them to a single value (the first one, modified).
+    # This is expected behavior per the multi-value PR design.
+    expected_content_one = <<-INIFILE
+        [main]
+        setting="value1 value2 newval"
+        other=data
+    INIFILE
+
+    it 'modifies the first occurrence and collapses multi-value keys when adding a subsetting' do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(setting: 'setting', subsetting: 'newval', value: '', quote_char: '"'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be_nil
+      provider.create
+      validate_file(expected_content_one, tmpfile)
+    end
+
+    expected_content_two = <<-INIFILE
+        [main]
+        setting="value2"
+        other=data
+    INIFILE
+
+    it 'removes a subsetting and collapses multi-value keys' do
+      resource = Puppet::Type::Ini_subsetting.new(common_params.merge(setting: 'setting', subsetting: 'value1', quote_char: '"'))
+      provider = described_class.new(resource)
+      provider.destroy
+      validate_file(expected_content_two, tmpfile)
+    end
+  end
 end

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -49,17 +49,17 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #section1' do
-      expect(ini_sub.get_settings('section1')).to eq('bar' => 'barvalue',
-                                                     'baz' => '',
-                                                     'foo' => 'foovalue')
+      expect(ini_sub.get_settings('section1')).to eq('bar' => ['barvalue'],
+                                                     'baz' => [''],
+                                                     'foo' => ['foovalue'])
     end
 
     it 'exposes settings for sections #section2' do
-      expect(ini_sub.get_settings('section2')).to eq('baz' => 'bazvalue',
-                                                     'foo' => 'foovalue2',
-                                                     'l' => 'git log',
-                                                     "xyzzy['thing1']['thing2']" => 'xyzzyvalue',
-                                                     'zot' => 'multi word value')
+      expect(ini_sub.get_settings('section2')).to eq('baz' => ['bazvalue'],
+                                                     'foo' => ['foovalue2'],
+                                                     'l' => ['git log'],
+                                                     "xyzzy['thing1']['thing2']" => ['xyzzyvalue'],
+                                                     'zot' => ['multi word value'])
     end
   end
 
@@ -84,7 +84,7 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections' do
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
   end
 
@@ -110,11 +110,11 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #bar' do
-      expect(ini_sub.get_value('', 'foo')).to eq('bar')
+      expect(ini_sub.get_value('', 'foo')).to eq(['bar'])
     end
 
     it 'exposes settings for sections #foovalue' do
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
   end
 
@@ -138,42 +138,42 @@ describe Puppet::Util::IniFile do
 
     it 'properlies update uncommented values' do
       ini_sub.set_value('section1', 'foo', ' = ', 'foovalue')
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
 
     it 'properlies update uncommented values without separator' do
       ini_sub.set_value('section1', 'foo', 'foovalue')
-      expect(ini_sub.get_value('section1', 'foo')).to eq('foovalue')
+      expect(ini_sub.get_value('section1', 'foo')).to eq(['foovalue'])
     end
 
     it 'properlies update commented value' do
       ini_sub.set_value('section1', 'bar', ' = ', 'barvalue')
-      expect(ini_sub.get_value('section1', 'bar')).to eq('barvalue')
+      expect(ini_sub.get_value('section1', 'bar')).to eq(['barvalue'])
     end
 
     it 'properlies update commented values' do
       ini_sub.set_value('section1', "xyzzy['thing1']['thing2']", ' = ', 'xyzzyvalue')
-      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq('xyzzyvalue')
+      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq(['xyzzyvalue'])
     end
 
     it 'properlies update commented value without separator' do
       ini_sub.set_value('section1', 'bar', 'barvalue')
-      expect(ini_sub.get_value('section1', 'bar')).to eq('barvalue')
+      expect(ini_sub.get_value('section1', 'bar')).to eq(['barvalue'])
     end
 
     it 'properlies update commented values without separator' do
       ini_sub.set_value('section1', "xyzzy['thing1']['thing2']", 'xyzzyvalue')
-      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq('xyzzyvalue')
+      expect(ini_sub.get_value('section1', "xyzzy['thing1']['thing2']")).to eq(['xyzzyvalue'])
     end
 
     it 'properlies add new empty values' do
       ini_sub.set_value('section1', 'baz', ' = ', 'bazvalue')
-      expect(ini_sub.get_value('section1', 'baz')).to eq('bazvalue')
+      expect(ini_sub.get_value('section1', 'baz')).to eq(['bazvalue'])
     end
 
     it 'adds new empty values without separator' do
       ini_sub.set_value('section1', 'baz', 'bazvalue')
-      expect(ini_sub.get_value('section1', 'baz')).to eq('bazvalue')
+      expect(ini_sub.get_value('section1', 'baz')).to eq(['bazvalue'])
     end
   end
 
@@ -254,11 +254,11 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #print' do
-      expect(ini_sub.get_value('khotkeys', '{5465e8c7-d608-4493-a48f-b99d99fdb508}')).to eq('Print,none,PrintScreen')
+      expect(ini_sub.get_value('khotkeys', '{5465e8c7-d608-4493-a48f-b99d99fdb508}')).to eq(['Print,none,PrintScreen'])
     end
 
     it 'exposes settings for sections #search' do
-      expect(ini_sub.get_value('khotkeys', '{d03619b6-9b3c-48cc-9d9c-a2aadb485550}')).to eq('Search,none,Search')
+      expect(ini_sub.get_value('khotkeys', '{d03619b6-9b3c-48cc-9d9c-a2aadb485550}')).to eq(['Search,none,Search'])
     end
   end
 
@@ -274,15 +274,15 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #A' do
-      expect(ini_sub.get_value('Drive names', 'A:')).to eq '5.25" Floppy'
+      expect(ini_sub.get_value('Drive names', 'A:')).to eq ['5.25" Floppy']
     end
 
     it 'exposes settings for sections #B' do
-      expect(ini_sub.get_value('Drive names', 'B:')).to eq '3.5" Floppy'
+      expect(ini_sub.get_value('Drive names', 'B:')).to eq ['3.5" Floppy']
     end
 
     it 'exposes settings for sections #C' do
-      expect(ini_sub.get_value('Drive names', 'C:')).to eq 'Winchester'
+      expect(ini_sub.get_value('Drive names', 'C:')).to eq ['Winchester']
     end
   end
 
@@ -301,19 +301,51 @@ describe Puppet::Util::IniFile do
     end
 
     it 'exposes settings for sections #log' do
-      expect(ini_sub.get_value('global', 'log file')).to eq '/var/log/samba/log.%m'
+      expect(ini_sub.get_value('global', 'log file')).to eq ['/var/log/samba/log.%m']
     end
 
     it 'exposes settings for sections #kerberos' do
-      expect(ini_sub.get_value('global', 'kerberos method')).to eq 'system keytab'
+      expect(ini_sub.get_value('global', 'kerberos method')).to eq ['system keytab']
     end
 
     it 'exposes settings for sections #passdb' do
-      expect(ini_sub.get_value('global', 'passdb backend')).to eq 'tdbsam'
+      expect(ini_sub.get_value('global', 'passdb backend')).to eq ['tdbsam']
     end
 
     it 'exposes settings for sections #security' do
-      expect(ini_sub.get_value('global', 'security')).to eq 'ads'
+      expect(ini_sub.get_value('global', 'security')).to eq ['ads']
+    end
+  end
+
+  context 'when using keys with multiple values' do
+    let(:sample_content) do
+      template = <<-EOS
+        [section]
+        foo=value1
+        foo=value2
+        bar=barvalue
+      EOS
+      template.split("\n")
+    end
+
+    it 'exposes settings for section #section' do
+      expect(ini_sub.get_settings('section')).to eq('foo' => ['value1', 'value2'],
+                                                    'bar' => ['barvalue'])
+    end
+
+    it 'adds multiple values' do
+      ini_sub.set_value('section', 'baz', ['bazvalue', 'bazvalue2'])
+      expect(ini_sub.get_value('section', 'baz')).to eq(['bazvalue', 'bazvalue2'])
+    end
+
+    it 'updates multiple values' do
+      ini_sub.set_value('section', 'bar', ['barvalue', 'barvalue2'])
+      expect(ini_sub.get_value('section', 'bar')).to eq(['barvalue', 'barvalue2'])
+    end
+
+    it 'removes extra values' do
+      ini_sub.set_value('section', 'foo', 'value2')
+      expect(ini_sub.get_value('section', 'foo')).to eq(['value2'])
     end
   end
 end


### PR DESCRIPTION
## Summary
This is a clone of https://github.com/puppetlabs/puppetlabs-inifile/pull/481 to hopefully get it passing and merged.

This change adds support for ini files in which the same key is used multiple times for lists of values, for example:

```
[section]
foo=a
foo=b
```

To set multiple values, an array of values can be passed to the value property of ini_setting.

When passing a single value, the module works as before, with one exception: when a single value is passed to value, but the ini file already contains multiple lines with the same key, any additional lines will now be removed instead of retained.

Thanks to @omolenkamp for the original PR.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppetlabs-inifile/issues/41
Related to https://github.com/puppetlabs/puppetlabs-inifile/pull/481

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)