### PR TITLE
ensure proper memoisation of inifile to prevent memory usage bloat 

### DIFF
--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -149,7 +149,13 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   private
 
   def ini_file
-    $ini_settings_ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
-    @ini_file = $ini_settings_ini_file
+    $ini_file_hash ||= { file_path => Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width) }
+    if $ini_file_hash[file_path]
+      @ini_file = $ini_file_hash[file_path]
+      return @ini_file
+    end
+    $ini_file_hash[file_path] = Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
+    @ini_file = $ini_file_hash[file_path]
+    @ini_file
   end
 end

--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -149,6 +149,7 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   private
 
   def ini_file
-    @ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
+    $ini_settings_ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
+    @ini_file = $ini_settings_ini_file
   end
 end

--- a/lib/puppet/provider/ini_setting/ruby.rb
+++ b/lib/puppet/provider/ini_setting/ruby.rb
@@ -60,13 +60,11 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
       ini_file.set_value(section, setting, separator, resource[:value])
     end
     ini_file.save
-    @ini_file = nil
   end
 
   def destroy
     ini_file.remove_setting(section, setting)
     ini_file.save
-    @ini_file = nil
   end
 
   def value
@@ -149,13 +147,6 @@ Puppet::Type.type(:ini_setting).provide(:ruby) do
   private
 
   def ini_file
-    $ini_file_hash ||= { file_path => Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width) }
-    if $ini_file_hash[file_path]
-      @ini_file = $ini_file_hash[file_path]
-      return @ini_file
-    end
-    $ini_file_hash[file_path] = Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
-    @ini_file = $ini_file_hash[file_path]
-    @ini_file
+    Puppet::Util::IniFile.cached(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
   end
 end

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -84,6 +84,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   private
 
   def ini_file
+    $ini_settings_ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
     @ini_file ||= Puppet::Util::IniFile.new(file_path, key_val_separator)
   end
 

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -84,8 +84,14 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   private
 
   def ini_file
-    $ini_settings_ini_file ||= Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
-    @ini_file ||= Puppet::Util::IniFile.new(file_path, key_val_separator)
+    $ini_file_hash ||= { file_path => Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width) }
+    if $ini_file_hash[file_path]
+      @ini_file = $ini_file_hash[file_path]
+      return @ini_file
+    end
+    $ini_file_hash[file_path] = Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
+    @ini_file = $ini_file_hash[file_path]
+    @ini_file
   end
 
   def setting_value

--- a/lib/puppet/provider/ini_subsetting/ruby.rb
+++ b/lib/puppet/provider/ini_subsetting/ruby.rb
@@ -20,7 +20,6 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
     )
     ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
     ini_file.save
-    @ini_file = nil
     @setting_value = nil
   end
 
@@ -32,7 +31,6 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
       ini_file.set_value(section, setting, key_val_separator, setting_value.get_value)
     end
     ini_file.save
-    @ini_file = nil
     @setting_value = nil
   end
 
@@ -84,14 +82,7 @@ Puppet::Type.type(:ini_subsetting).provide(:ruby) do
   private
 
   def ini_file
-    $ini_file_hash ||= { file_path => Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width) }
-    if $ini_file_hash[file_path]
-      @ini_file = $ini_file_hash[file_path]
-      return @ini_file
-    end
-    $ini_file_hash[file_path] = Puppet::Util::IniFile.new(file_path, separator, section_prefix, section_suffix, indent_char, indent_width)
-    @ini_file = $ini_file_hash[file_path]
-    @ini_file
+    Puppet::Util::IniFile.cached(file_path, key_val_separator)
   end
 
   def setting_value

--- a/lib/puppet/util/ini_file.rb
+++ b/lib/puppet/util/ini_file.rb
@@ -8,6 +8,14 @@ module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
   # ini_file.rb
   #
   class IniFile
+    def self.cached(path, key_val_separator = ' = ', section_prefix = '[',
+                    section_suffix = ']', indent_char = ' ', indent_width = nil)
+      @instance_cache ||= {}
+      cache_key = [path, key_val_separator, section_prefix, section_suffix, indent_char, indent_width]
+      @instance_cache[cache_key] ||= new(path, key_val_separator, section_prefix,
+                                         section_suffix, indent_char, indent_width)
+    end
+
     def initialize(path, key_val_separator = ' = ', section_prefix = '[', section_suffix = ']',
                    indent_char = ' ', indent_width = nil)
 

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -25,6 +25,7 @@ describe provider_class do
   before :each do
     File.write(tmpfile, orig_content)
     File.write(emptyfile, '')
+    Puppet::Util::IniFile.instance_variable_set(:@instance_cache, nil)
   end
 
   context 'when calling instances' do
@@ -1723,8 +1724,9 @@ baz = newvalue
       provider2 = described_class.new(resource2)
       provider2.create
 
-      # Now reset file and do both operations to verify section line tracking
+      # Now reset file and cache to do both operations fresh
       File.write(tmpfile, orig_content)
+      Puppet::Util::IniFile.instance_variable_set(:@instance_cache, nil)
       resource3 = Puppet::Type::Ini_setting.new(common_params.merge(section: 'section3', setting: 'baz', value: 'newvalue'))
       provider3 = described_class.new(resource3)
       provider3.create

--- a/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_setting/ruby_spec.rb
@@ -1733,4 +1733,70 @@ baz = newvalue
       validate_file(expected_content_six, tmpfile)
     end
   end
+
+  context 'when making sequential reads and writes with new provider instances' do
+    include PuppetlabsSpec::Files
+
+    let(:orig_content) { '' }
+    let(:seq_file) { tmpfilename('ini_setting_sequential') }
+
+    before :each do
+      File.write(seq_file, "[section]\nkey = original\n")
+      Puppet::Util::IniFile.instance_variable_set(:@instance_cache, nil)
+    end
+
+    def make_provider(attrs)
+      resource = Puppet::Type::Ini_setting.new(
+        { title: 'seq_test', path: seq_file, section: 'section' }.merge(attrs)
+      )
+      described_class.new(resource)
+    end
+
+    it 'new provider instance reads the value written by a previous provider' do
+      make_provider(setting: 'key', value: 'updated').create
+
+      reader = make_provider(setting: 'key', value: 'irrelevant')
+      expect(reader.value).to eq(['updated'])
+    end
+
+    it 'two sequential writes accumulate correctly on disk' do
+      make_provider(setting: 'key', value: 'first').create
+      make_provider(setting: 'other', value: 'second').create
+
+      content = File.read(seq_file)
+      expect(content).to include('key = first')
+      expect(content).to include('other = second')
+    end
+
+    it 'new provider instance sees a setting created by a previous provider' do
+      make_provider(setting: 'newkey', value: 'newval').create
+
+      reader = make_provider(setting: 'newkey', value: 'irrelevant')
+      expect(reader.exists?).to be true
+      expect(reader.value).to eq(['newval'])
+    end
+
+    it 'new provider instance destroys a setting created by a previous provider' do
+      make_provider(setting: 'key', value: 'updated').create
+      make_provider(setting: 'key', value: 'irrelevant').destroy
+
+      content = File.read(seq_file)
+      expect(content).not_to include('key')
+    end
+
+    it 'write then read with a different key_val_separator uses a separate cache entry' do
+      make_provider(setting: 'key', value: 'eqval').create
+
+      colon_resource = Puppet::Type::Ini_setting.new(
+        title: 'seq_colon', path: seq_file, section: 'section',
+        setting: 'key', value: 'colonval', key_val_separator: ':'
+      )
+      colon_provider = described_class.new(colon_resource)
+      colon_provider.create
+
+      content = File.read(seq_file)
+      expect(content).to include('key = eqval')
+      expect(content).to include('key:colonval')
+    end
+  end
 end

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -419,6 +419,74 @@ describe provider_class do
     end
   end
 
+  context 'when making sequential reads and writes with new provider instances' do
+    include PuppetlabsSpec::Files
+
+    let(:orig_content) { '' }
+    let(:seq_file) { tmpfilename('ini_subsetting_sequential') }
+
+    before :each do
+      File.write(seq_file, "[section]\nJAVA_ARGS=\"-Xmx192m -Xms64m\"\n")
+      Puppet::Util::IniFile.instance_variable_set(:@instance_cache, nil)
+    end
+
+    def make_provider(attrs)
+      resource = Puppet::Type::Ini_subsetting.new(
+        {
+          title: 'seq_test', path: seq_file, section: 'section',
+          setting: 'JAVA_ARGS', key_val_separator: '='
+        }.merge(attrs)
+      )
+      described_class.new(resource)
+    end
+
+    it 'new provider instance reads the subsetting value written by a previous provider' do
+      make_provider(subsetting: '-Xmx', value: '512m').value = '512m'
+
+      reader = make_provider(subsetting: '-Xmx', value: 'irrelevant')
+      expect(reader.value).to eq('512m')
+    end
+
+    it 'two sequential writes accumulate correctly on disk' do
+      make_provider(subsetting: '-Xmx', value: '512m').create
+      make_provider(subsetting: '-Xms', value: '256m').create
+
+      content = File.read(seq_file)
+      expect(content).to include('-Xmx512m')
+      expect(content).to include('-Xms256m')
+    end
+
+    it 'new provider instance sees a subsetting created by a previous provider' do
+      make_provider(subsetting: '-Xss', value: '8m').create
+
+      reader = make_provider(subsetting: '-Xss', value: 'irrelevant')
+      expect(reader.exists?).to eq('8m')
+    end
+
+    it 'new provider instance destroys a subsetting created by a previous provider' do
+      make_provider(subsetting: '-Xmx', value: '512m').create
+      make_provider(subsetting: '-Xmx', value: 'irrelevant').destroy
+
+      content = File.read(seq_file)
+      expect(content).not_to include('-Xmx')
+    end
+
+    it 'write then read with a different key_val_separator uses a separate cache entry' do
+      make_provider(subsetting: '-Xmx', value: '512m').create
+
+      colon_resource = Puppet::Type::Ini_subsetting.new(
+        title: 'seq_colon', path: seq_file, section: 'section',
+        setting: 'JAVA_ARGS', subsetting: '-Xmx', value: '256m', key_val_separator: ':'
+      )
+      colon_provider = described_class.new(colon_resource)
+      colon_provider.create
+
+      ini_eq    = Puppet::Util::IniFile.cached(seq_file, '=')
+      ini_colon = Puppet::Util::IniFile.cached(seq_file, ':')
+      expect(ini_eq).not_to equal(ini_colon)
+    end
+  end
+
   context 'when ini_setting and ini_subsetting target the same file' do
     include PuppetlabsSpec::Files
 

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'puppet'
 
+Puppet::Type.type(:ini_setting)
 provider_class = Puppet::Type.type(:ini_subsetting).provider(:ruby)
 describe provider_class do
   include PuppetlabsSpec::Files

--- a/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/ini_subsetting/ruby_spec.rb
@@ -15,6 +15,7 @@ describe provider_class do
 
   before :each do
     File.write(tmpfile, orig_content)
+    Puppet::Util::IniFile.instance_variable_set(:@instance_cache, nil)
   end
 
   context 'when ensuring that a subsetting is present' do
@@ -414,6 +415,57 @@ describe provider_class do
       provider = described_class.new(resource)
       provider.destroy
       validate_file(expected_content_two, tmpfile)
+    end
+  end
+
+  context 'when ini_setting and ini_subsetting target the same file' do
+    include PuppetlabsSpec::Files
+
+    let(:orig_content) { '' }
+    let(:shared_file) { tmpfilename('shared_ini_file') }
+
+    before :each do
+      File.write(shared_file, "[section]\nkey=value\n")
+      Puppet::Util::IniFile.instance_variable_set(:@instance_cache, nil)
+    end
+
+    it 'does not raise NoMethodError when ini_subsetting calls ini_file' do
+      resource = Puppet::Type::Ini_subsetting.new(
+        title: 'test', path: shared_file, section: 'section',
+        setting: 'key', subsetting: 'val', key_val_separator: '='
+      )
+      provider = Puppet::Type::Ini_subsetting.provider(:ruby).new(resource)
+      expect { provider.send(:ini_file) }.not_to raise_error
+    end
+
+    it 'shares one IniFile object when key_val_separator matches between providers' do
+      setting_resource = Puppet::Type::Ini_setting.new(
+        title: 'test_setting', path: shared_file, section: 'section',
+        setting: 'key', value: 'val', key_val_separator: '='
+      )
+      subsetting_resource = Puppet::Type::Ini_subsetting.new(
+        title: 'test_subsetting', path: shared_file, section: 'section',
+        setting: 'key', subsetting: 'val', key_val_separator: '='
+      )
+      setting_provider    = Puppet::Type::Ini_setting.provider(:ruby).new(setting_resource)
+      subsetting_provider = Puppet::Type::Ini_subsetting.provider(:ruby).new(subsetting_resource)
+
+      expect(setting_provider.send(:ini_file)).to equal(subsetting_provider.send(:ini_file))
+    end
+
+    it 'uses distinct IniFile objects when key_val_separator differs between providers' do
+      setting_resource = Puppet::Type::Ini_setting.new(
+        title: 'test_setting', path: shared_file, section: 'section',
+        setting: 'key', value: 'val', key_val_separator: ':'
+      )
+      subsetting_resource = Puppet::Type::Ini_subsetting.new(
+        title: 'test_subsetting', path: shared_file, section: 'section',
+        setting: 'key', subsetting: 'val', key_val_separator: '='
+      )
+      setting_provider    = Puppet::Type::Ini_setting.provider(:ruby).new(setting_resource)
+      subsetting_provider = Puppet::Type::Ini_subsetting.provider(:ruby).new(subsetting_resource)
+
+      expect(setting_provider.send(:ini_file)).not_to equal(subsetting_provider.send(:ini_file))
     end
   end
 end

--- a/spec/unit/puppet/util/ini_file_spec.rb
+++ b/spec/unit/puppet/util/ini_file_spec.rb
@@ -348,4 +348,50 @@ describe Puppet::Util::IniFile do
       expect(ini_sub.get_value('section', 'foo')).to eq(['value2'])
     end
   end
+
+  describe '.cached' do
+    let(:path) { '/my/ini/file/path' }
+
+    before :each do
+      described_class.instance_variable_set(:@instance_cache, nil)
+      allow(File).to receive(:file?).with(path).and_return(true)
+      allow(described_class).to receive(:readlines).with(path).and_return([])
+    end
+
+    it 'returns an IniFile instance' do
+      expect(described_class.cached(path)).to be_a(described_class)
+    end
+
+    it 'returns the same object on repeated calls with identical params' do
+      first  = described_class.cached(path, '=')
+      second = described_class.cached(path, '=')
+      expect(first).to equal(second)
+    end
+
+    it 'only parses the file once for repeated calls with identical params' do
+      expect(described_class).to receive(:readlines).once.and_return([])
+      described_class.cached(path, '=')
+      described_class.cached(path, '=')
+    end
+
+    it 'returns distinct objects for different key_val_separator values on the same path' do
+      eq_obj    = described_class.cached(path, '=')
+      colon_obj = described_class.cached(path, ':')
+      expect(eq_obj).not_to equal(colon_obj)
+    end
+
+    it 'returns distinct objects for different section_prefix values on the same path' do
+      bracket_obj = described_class.cached(path, '=', '[')
+      dash_obj    = described_class.cached(path, '=', '-')
+      expect(bracket_obj).not_to equal(dash_obj)
+    end
+
+    it 'does not share cache with subclasses' do
+      subclass = Class.new(described_class)
+      allow(subclass).to receive(:readlines).with(path).and_return([])
+      parent_obj   = described_class.cached(path, '=')
+      subclass_obj = subclass.cached(path, '=')
+      expect(parent_obj).not_to equal(subclass_obj)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Provide a detailed description of all the changes present in this pull request.

### Note
I used Claude code in authoring this MR. I have reviewed every line of code changed and validated manually using the tests below to ensure the performance bug is fixed but am mostly depending on unit tests to ensure there are no other unforeseen regressions (outside of new unit tests added)

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
  - steps to reproduce:
    - create a local test puppet file which looks something like:
```
$ cat test_10000_settings.pp
node default {
  $settings_file = '/tmp/test_1000_settings.ini'

  Integer[1, 10000].each |$i| {
    ini_setting { "setting_${i}":
      ensure  => present,
      path    => $settings_file,
      section => "section_${i}",
      setting => "key_${i}",
      value   => "value_${i}",
    }
  }
}
```
   - then run `puppet apply test_10000_settings.pp` and monitor memory usage in another tab/session
   - the first time around - we use of the order of 500MB of mem
   - kill the apply around the 1000 settings mark
   - rerun the apply and monitor memory usage again - memory usage should be up to ~1GB this time
   - you can let apply continue to 2000 mark this time.. kill and rerun.. check mem.. should have roughly doubled
   - .. continue adding and observe doubling of memory with each extra attempt    

- [x] Thought process behind the implementation.
  - @ini_file is read for every ini_setting and then set to nil at the end
  - this results is each ini_setting resource resulting in re-reading the file to memory instead of reusing the memoised copy
  - creating the global helps by ensuring different settings within the same file reuse the memoised copy
  
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`): manually verified by re-running the reproduction steps above  and on local machine memory usage stays steady during apply time (around 350MB in this specific test) instead of increasing with file size and/or no. of ini_settings managed